### PR TITLE
fix: add file existence checks before copying script modules

### DIFF
--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -36,8 +36,9 @@ install_tools() {
 
 # Setup credential management scripts
 setup_credential_scripts() {
-    # Copy modular scripts to system locations
-    if [ -d "/config/scripts" ]; then
+    # Copy modular scripts to system locations if they exist
+    if [ -d "/config/scripts" ] && [ -f "/config/scripts/credentials-manager.sh" ] && [ -f "/config/scripts/credentials-service.sh" ] && [ -f "/config/scripts/claude-auth.sh" ]; then
+        bashio::log.info "Found modular scripts, copying to system locations..."
         if ! cp /config/scripts/credentials-manager.sh /usr/local/bin/credentials-manager; then
             bashio::log.error "Failed to copy credentials-manager script"
             exit 1
@@ -50,9 +51,10 @@ setup_credential_scripts() {
             bashio::log.error "Failed to copy claude-auth script"
             exit 1
         fi
+        bashio::log.info "Modular scripts copied successfully"
     else
         # Fallback to embedded scripts for backward compatibility
-        bashio::log.warning "Script modules not found, using embedded versions"
+        bashio::log.info "Modular scripts not found in /config/scripts, using embedded versions"
         
         # Create embedded credentials-manager script
         cat > /usr/local/bin/credentials-manager << 'EOF'


### PR DESCRIPTION
## Summary
- Fixes add-on startup failure when modular script files are missing
- Adds proper file existence checks before attempting to copy scripts
- Improves logging to show which script version is being used

## Problem
The add-on was failing to start for new installations because it attempted to copy modular script files that don't exist by default. This caused a fatal error during the setup phase, preventing the add-on from starting.

## Solution
Added comprehensive file existence checks that verify all three required script files are present before attempting to copy them. If any file is missing, the add-on falls back to using embedded script versions.

## Changes
- Added existence check for all three script files (`credentials-manager.sh`, `credentials-service.sh`, `claude-auth.sh`)
- Added informative logging messages to indicate which script version is being used
- Changed warning message to info level for the fallback case (since it's normal behavior)

## Testing
- ✅ Add-on starts successfully without modular scripts (uses embedded versions)
- ✅ Add-on starts successfully with modular scripts present (uses modular versions)
- ✅ Appropriate log messages are displayed in both scenarios

## Related Issues
Fixes #6 - "not starting" error reported by @remb0
Closes #9 - Detailed issue description

🤖 Generated with [Claude Code](https://claude.ai/code)