### PR TITLE
feat: add nano text editor to Claude Terminal add-on

### DIFF
--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     npm \
     bash \
     curl \
+    nano \
     && npm install -g @anthropic-ai/claude-code@latest \
     && npm cache clean --force
 


### PR DESCRIPTION
Added nano to the apk package installation list to provide users with a lightweight text editor option within the container environment.

This allows `/memory` to work. 

🤖 Generated with [Claude Code](https://claude.ai/code)