### PR TITLE
Fix: Implement persistent authentication for Claude Code OAuth tokens

### DIFF
--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,6 +1,6 @@
 name: "Claude Terminal"
-description: "Terminal interface for Anthropic's Claude Code CLI"
-version: "1.1.4"
+description: "Terminal interface for Anthropic's Claude Code CLI with persistent authentication"
+version: "1.2.0"
 slug: "claude_terminal"
 init: false
 
@@ -34,10 +34,7 @@ options:
 schema:
   auto_launch_claude: bool?
 
-# Volume mapping for persistent storage
-map:
-  - config:rw    # Claude configuration and credentials
-  - addons:rw    # Access to other add-ons for development
+# No volume mappings needed - using /data (always available and writable)
 
 # Service startup configuration
 startup: services


### PR DESCRIPTION
## Summary
  Fixes the critical authentication persistence issue where Claude Code OAuth tokens were lost on container restarts, requiring users to re-authenticate every time.

  ## Solution
  - **Switched from `/config` to `/data`** - Uses Home Assistant's guaranteed-writable directory
  - **XDG Base Directory compliance** - Proper environment variable configuration
  - **Legacy migration** - Automatically migrates existing auth files
  - **Simplified architecture** - Removed complex symlink/monitoring systems per expert AI consensus

  ## Technical Changes
  - `config.yaml`: Updated to v1.2.0, removed unnecessary volume mappings
  - `run.sh`: Complete rewrite using `/data` exclusively with XDG environment variables
  - Backward compatible with existing installations

  ## Testing
  ✅ Tested successfully on HAOS 16.1 (ProxMox VM)
  ✅ Authentication persists across container restarts
  ✅ Both auto-launch and session picker modes work

  ## Impact
  - **Fixes**: OAuth authentication persistence across restarts
  - **Improves**: User experience (no repeated authentication)
  - **Maintains**: Full backward compatibility

  This follows Home Assistant Supervisor best practices and expert recommendations from multiple AI model consultation.

  The pull request will contribute your working v1.2.0 fix back to the original repository so other users can benefit from the authentication persistence solution.

