### PR TITLE
docs: update repository URL to forked version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To add this repository to your Home Assistant instance:
 1. Go to **Settings** → **Add-ons** → **Add-on Store**
 2. Click the three dots menu in the top right corner
 3. Select **Repositories**
-4. Add the URL: `https://github.com/heytcass/home-assistant-addons`
+4. Add the URL: `https://github.com/beyer-martin/home-assistant-addons`
 5. Click **Add**
 
 ## Add-ons


### PR DESCRIPTION
Updated installation instructions in README.md to reference the forked repository (beyer-martin/home-assistant-addons) instead of the original (heytcass/home-assistant-addons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)