### PR TITLE
Add Home Assistant CLI (ha) access to Claude Terminal

### DIFF
--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -1,6 +1,10 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
+# Build arguments for Home Assistant CLI
+ARG BUILD_ARCH
+ARG CLI_VERSION=4.38.1
+
 # Install packages in a single layer to minimize image size
 # Add retry logic for npm installation to handle network issues
 RUN apk add --no-cache \
@@ -22,6 +26,11 @@ RUN apk add --no-cache \
         (echo "Attempt $i failed, retrying in 10 seconds..." && sleep 10); \
     done \
     && npm cache clean --force
+
+# Install Home Assistant CLI
+RUN curl -Lso /usr/bin/ha \
+    "https://github.com/home-assistant/cli/releases/download/${CLI_VERSION}/ha_${BUILD_ARCH}" \
+    && chmod a+x /usr/bin/ha
 
 # Create directory for Claude configuration and set working directory
 RUN mkdir -p /config/claude-config

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -44,6 +44,7 @@ hassio_api: true
 hassio_role: manager
 homeassistant_api: true
 auth_api: true
+host_dbus: true
 
 # Service startup configuration
 startup: services


### PR DESCRIPTION
Enables Claude Code to use Home Assistant CLI commands (ha core, ha addons, ha backups, etc.) directly within the terminal. This brings parity with the official SSH/Terminal addons.

Changes:
- Download and install ha CLI binary from official releases (v4.38.1)
- Add BUILD_ARCH argument to support multi-architecture builds
- Enable host_dbus access for full ha command functionality
- Install ha to /usr/bin/ha with proper permissions

The ha CLI will have manager-level access through existing hassio_api and hassio_role configuration.