### PR TITLE
feat: Add persistent package management (#32)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 1.5.0
+
+### ✨ New Features
+- **Persistent Package Management** (#32): Install APK and pip packages that survive container restarts
+  - New `persist-install` command for installing packages from the terminal
+  - Configuration options: `persistent_apk_packages` and `persistent_pip_packages`
+  - Packages installed via command or config are automatically reinstalled on startup
+  - Supports both Home Assistant add-on config and local state file
+  - Inspired by community contribution from [@ESJavadex](https://github.com/ESJavadex)
+
+### 📦 Usage Examples
+```bash
+# Install APK packages persistently
+persist-install apk vim htop
+
+# Install pip packages persistently
+persist-install pip requests pandas numpy
+
+# List all persistent packages
+persist-install list
+
+# Remove from persistence (package remains until restart)
+persist-install remove apk vim
+```
+
+### 🛠️ Configuration
+Add to your add-on config to auto-install packages:
+```yaml
+persistent_apk_packages:
+  - vim
+  - htop
+persistent_pip_packages:
+  - requests
+  - pandas
+```
+
 ## 1.4.1
 
 ### 🐛 Bug Fixes

--- a/claude-terminal/README.md
+++ b/claude-terminal/README.md
@@ -27,6 +27,7 @@ This add-on provides a web-based terminal interface with Claude Code CLI pre-ins
 - **Multi-Architecture Support**: Works on amd64, aarch64, and armv7 platforms
 - **Secure Credential Management**: Persistent authentication with safe credential storage
 - **Automatic Recovery**: Built-in fallbacks and error handling for reliable operation
+- **Persistent Package Management**: Install APK and pip packages that survive container restarts
 
 ## Quick Start
 
@@ -47,6 +48,13 @@ claude-auth debug
 
 # Log out and re-authenticate
 claude-logout
+
+# Install packages that persist across restarts
+persist-install apk vim htop
+persist-install pip requests pandas
+
+# List persistent packages
+persist-install list
 ```
 
 ## Installation
@@ -59,12 +67,32 @@ claude-logout
 
 ## Configuration
 
-The add-on requires no configuration. All settings are handled automatically:
+The add-on works out of the box with sensible defaults. Optional configuration:
 
+| Option | Default | Description |
+|--------|---------|-------------|
+| `auto_launch_claude` | `true` | Auto-start Claude on terminal open (set to `false` for session picker) |
+| `persistent_apk_packages` | `[]` | List of APK packages to install on startup |
+| `persistent_pip_packages` | `[]` | List of pip packages to install on startup |
+
+### Example Configuration
+```yaml
+auto_launch_claude: true
+persistent_apk_packages:
+  - vim
+  - htop
+  - rsync
+persistent_pip_packages:
+  - requests
+  - pandas
+  - numpy
+```
+
+### Default Settings
 - **Port**: Web interface runs on port 7681
-- **Authentication**: OAuth with Anthropic (credentials stored securely in `/config/claude-config/`)
+- **Authentication**: OAuth with Anthropic (credentials stored securely in `/data/.config/claude/`)
 - **Terminal**: Full bash environment with Claude Code CLI pre-installed
-- **Volumes**: Access to both `/config` (Home Assistant) and `/addons` (for development)
+- **Volumes**: Access to `/config` (Home Assistant configuration)
 
 ## Troubleshooting
 
@@ -134,21 +162,23 @@ For detailed usage instructions, see the [documentation](DOCS.md).
 
 ## Version History
 
-### v1.0.2 (Current) - Security & Bug Fix Release
-- 🔒 **CRITICAL**: Fixed dangerous filesystem operations
-- 🐛 Added missing armv7 architecture support
-- 🔧 Pinned NPM packages and improved error handling
-- 🛠️ Enhanced development environment with Podman support
+### v1.5.0 (Current) - Persistent Packages
+- **Persistent Package Management**: Install APK and pip packages that survive restarts
+- New `persist-install` command for easy package management
+- Configuration options for auto-installing packages on startup
+- Inspired by community contributions from [@ESJavadex](https://github.com/ESJavadex)
 
-### v1.0.1
-- Improved credential management
-- Enhanced startup reliability
+### v1.4.x
+- Added Python 3.11 and development tools (git, vim, jq, wget, tree)
+- ttyd keepalive options to prevent WebSocket disconnects
+- Home Assistant API access with examples
 
-### v1.0.0
-- Initial stable release
-- Web terminal interface with ttyd
-- Pre-installed Claude Code CLI
-- OAuth authentication support
+### v1.3.x
+- Interactive session picker menu
+- Authentication helper for clipboard issues
+- Health check diagnostics
+
+See [CHANGELOG.md](CHANGELOG.md) for complete version history.
 
 ## Useful Links
 

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
-description: "Terminal interface for Anthropic's Claude Code CLI with persistent auth"
-version: "1.4.2"
+description: "Terminal interface for Anthropic's Claude Code CLI with persistent auth and packages"
+version: "1.5.0"
 slug: "claude_terminal"
 init: false
 
@@ -29,11 +29,15 @@ ports_description:
 
 # Add-on configuration options
 options:
-  auto_launch_claude:
-    name: "Auto-launch Claude"
-    description: "Auto-start Claude on terminal open (disable for session picker)"
+  auto_launch_claude: true
+  persistent_apk_packages: []
+  persistent_pip_packages: []
 schema:
   auto_launch_claude: bool?
+  persistent_apk_packages:
+    - str
+  persistent_pip_packages:
+    - str
 
 # Volume mappings for file access
 map:

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -99,6 +99,84 @@ install_tools() {
     bashio::log.info "Tools installed successfully"
 }
 
+# Install persistent packages from config and saved state
+install_persistent_packages() {
+    bashio::log.info "Checking for persistent packages..."
+
+    local persist_config="/data/persistent-packages.json"
+    local apk_packages=""
+    local pip_packages=""
+
+    # Collect APK packages from Home Assistant config
+    if bashio::config.has_value 'persistent_apk_packages'; then
+        local config_apk
+        config_apk=$(bashio::config 'persistent_apk_packages')
+        if [ -n "$config_apk" ] && [ "$config_apk" != "null" ]; then
+            apk_packages="$config_apk"
+            bashio::log.info "Found APK packages in config: $apk_packages"
+        fi
+    fi
+
+    # Collect pip packages from Home Assistant config
+    if bashio::config.has_value 'persistent_pip_packages'; then
+        local config_pip
+        config_pip=$(bashio::config 'persistent_pip_packages')
+        if [ -n "$config_pip" ] && [ "$config_pip" != "null" ]; then
+            pip_packages="$config_pip"
+            bashio::log.info "Found pip packages in config: $pip_packages"
+        fi
+    fi
+
+    # Also check local persist-install config file
+    if [ -f "$persist_config" ]; then
+        bashio::log.info "Found local persistent packages config"
+
+        # Get APK packages from local config
+        local local_apk
+        local_apk=$(jq -r '.apk_packages | join(" ")' "$persist_config" 2>/dev/null || echo "")
+        if [ -n "$local_apk" ]; then
+            apk_packages="$apk_packages $local_apk"
+        fi
+
+        # Get pip packages from local config
+        local local_pip
+        local_pip=$(jq -r '.pip_packages | join(" ")' "$persist_config" 2>/dev/null || echo "")
+        if [ -n "$local_pip" ]; then
+            pip_packages="$pip_packages $local_pip"
+        fi
+    fi
+
+    # Trim whitespace and remove duplicates
+    apk_packages=$(echo "$apk_packages" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
+    pip_packages=$(echo "$pip_packages" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
+
+    # Install APK packages
+    if [ -n "$apk_packages" ]; then
+        bashio::log.info "Installing persistent APK packages: $apk_packages"
+        # shellcheck disable=SC2086
+        if apk add --no-cache $apk_packages; then
+            bashio::log.info "APK packages installed successfully"
+        else
+            bashio::log.warning "Some APK packages failed to install"
+        fi
+    fi
+
+    # Install pip packages
+    if [ -n "$pip_packages" ]; then
+        bashio::log.info "Installing persistent pip packages: $pip_packages"
+        # shellcheck disable=SC2086
+        if pip3 install --no-cache-dir $pip_packages; then
+            bashio::log.info "pip packages installed successfully"
+        else
+            bashio::log.warning "Some pip packages failed to install"
+        fi
+    fi
+
+    if [ -z "$apk_packages" ] && [ -z "$pip_packages" ]; then
+        bashio::log.info "No persistent packages configured"
+    fi
+}
+
 # Setup session picker script
 setup_session_picker() {
     # Copy session picker script from built-in location
@@ -117,6 +195,16 @@ setup_session_picker() {
     if [ -f "/opt/scripts/claude-auth-helper.sh" ]; then
         chmod +x /opt/scripts/claude-auth-helper.sh
         bashio::log.info "Authentication helper script ready"
+    fi
+
+    # Setup persist-install script if it exists
+    if [ -f "/opt/scripts/persist-install.sh" ]; then
+        if ! cp /opt/scripts/persist-install.sh /usr/local/bin/persist-install; then
+            bashio::log.warning "Failed to copy persist-install script"
+        else
+            chmod +x /usr/local/bin/persist-install
+            bashio::log.info "Persist-install script installed successfully"
+        fi
     fi
 }
 
@@ -196,6 +284,7 @@ main() {
     init_environment
     install_tools
     setup_session_picker
+    install_persistent_packages
     start_web_terminal
 }
 

--- a/claude-terminal/scripts/persist-install.sh
+++ b/claude-terminal/scripts/persist-install.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/with-contenv bashio
+#
+# persist-install - Install packages that persist across container restarts
+#
+# Usage:
+#   persist-install apk <package1> [package2] ...  - Install APK packages
+#   persist-install pip <package1> [package2] ...  - Install pip packages
+#   persist-install list                           - List persistent packages
+#   persist-install help                           - Show this help message
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Config file for tracking installed packages (persisted in /data)
+PERSIST_CONFIG="/data/persistent-packages.json"
+
+# Initialize config file if it doesn't exist
+init_config() {
+    if [ ! -f "$PERSIST_CONFIG" ]; then
+        echo '{"apk_packages": [], "pip_packages": []}' > "$PERSIST_CONFIG"
+    fi
+}
+
+# Show help message
+show_help() {
+    echo -e "${BLUE}persist-install${NC} - Install packages that persist across container restarts"
+    echo ""
+    echo "Usage:"
+    echo "  persist-install apk <package1> [package2] ...  - Install APK packages"
+    echo "  persist-install pip <package1> [package2] ...  - Install pip packages"
+    echo "  persist-install list                           - List persistent packages"
+    echo "  persist-install remove apk <package>           - Remove APK package from persistence"
+    echo "  persist-install remove pip <package>           - Remove pip package from persistence"
+    echo "  persist-install help                           - Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  persist-install apk vim htop"
+    echo "  persist-install pip requests pandas numpy"
+    echo "  persist-install list"
+    echo ""
+    echo -e "${YELLOW}Note:${NC} Packages are installed immediately and will be reinstalled"
+    echo "      automatically after container restarts."
+}
+
+# List installed packages
+list_packages() {
+    init_config
+
+    echo -e "${BLUE}Persistent Packages${NC}"
+    echo "==================="
+    echo ""
+
+    echo -e "${GREEN}APK Packages:${NC}"
+    local apk_packages
+    apk_packages=$(jq -r '.apk_packages[]' "$PERSIST_CONFIG" 2>/dev/null || echo "")
+    if [ -z "$apk_packages" ]; then
+        echo "  (none)"
+    else
+        echo "$apk_packages" | while read -r pkg; do
+            echo "  - $pkg"
+        done
+    fi
+
+    echo ""
+    echo -e "${GREEN}Pip Packages:${NC}"
+    local pip_packages
+    pip_packages=$(jq -r '.pip_packages[]' "$PERSIST_CONFIG" 2>/dev/null || echo "")
+    if [ -z "$pip_packages" ]; then
+        echo "  (none)"
+    else
+        echo "$pip_packages" | while read -r pkg; do
+            echo "  - $pkg"
+        done
+    fi
+}
+
+# Install APK packages
+install_apk() {
+    init_config
+
+    if [ $# -eq 0 ]; then
+        echo -e "${RED}Error:${NC} No packages specified"
+        echo "Usage: persist-install apk <package1> [package2] ..."
+        exit 1
+    fi
+
+    local packages=("$@")
+
+    echo -e "${BLUE}Installing APK packages:${NC} ${packages[*]}"
+
+    # Install packages
+    if apk add --no-cache "${packages[@]}"; then
+        echo -e "${GREEN}Installation successful!${NC}"
+
+        # Add to persistence config
+        for pkg in "${packages[@]}"; do
+            # Check if already in list
+            if ! jq -e ".apk_packages | index(\"$pkg\")" "$PERSIST_CONFIG" > /dev/null 2>&1; then
+                jq ".apk_packages += [\"$pkg\"]" "$PERSIST_CONFIG" > "${PERSIST_CONFIG}.tmp"
+                mv "${PERSIST_CONFIG}.tmp" "$PERSIST_CONFIG"
+                echo -e "${GREEN}+${NC} Added '$pkg' to persistent packages"
+            else
+                echo -e "${YELLOW}!${NC} '$pkg' already in persistent packages"
+            fi
+        done
+    else
+        echo -e "${RED}Installation failed!${NC}"
+        exit 1
+    fi
+}
+
+# Install pip packages
+install_pip() {
+    init_config
+
+    if [ $# -eq 0 ]; then
+        echo -e "${RED}Error:${NC} No packages specified"
+        echo "Usage: persist-install pip <package1> [package2] ..."
+        exit 1
+    fi
+
+    local packages=("$@")
+
+    echo -e "${BLUE}Installing pip packages:${NC} ${packages[*]}"
+
+    # Install packages
+    if pip3 install --no-cache-dir "${packages[@]}"; then
+        echo -e "${GREEN}Installation successful!${NC}"
+
+        # Add to persistence config
+        for pkg in "${packages[@]}"; do
+            # Check if already in list (normalize package name)
+            local pkg_lower
+            pkg_lower=$(echo "$pkg" | tr '[:upper:]' '[:lower:]')
+            if ! jq -e ".pip_packages | map(ascii_downcase) | index(\"$pkg_lower\")" "$PERSIST_CONFIG" > /dev/null 2>&1; then
+                jq ".pip_packages += [\"$pkg\"]" "$PERSIST_CONFIG" > "${PERSIST_CONFIG}.tmp"
+                mv "${PERSIST_CONFIG}.tmp" "$PERSIST_CONFIG"
+                echo -e "${GREEN}+${NC} Added '$pkg' to persistent packages"
+            else
+                echo -e "${YELLOW}!${NC} '$pkg' already in persistent packages"
+            fi
+        done
+    else
+        echo -e "${RED}Installation failed!${NC}"
+        exit 1
+    fi
+}
+
+# Remove package from persistence
+remove_package() {
+    init_config
+
+    local pkg_type="$1"
+    local pkg_name="$2"
+
+    if [ -z "$pkg_type" ] || [ -z "$pkg_name" ]; then
+        echo -e "${RED}Error:${NC} Missing arguments"
+        echo "Usage: persist-install remove <apk|pip> <package>"
+        exit 1
+    fi
+
+    case "$pkg_type" in
+        apk)
+            jq "del(.apk_packages[] | select(. == \"$pkg_name\"))" "$PERSIST_CONFIG" > "${PERSIST_CONFIG}.tmp"
+            mv "${PERSIST_CONFIG}.tmp" "$PERSIST_CONFIG"
+            echo -e "${GREEN}-${NC} Removed '$pkg_name' from persistent APK packages"
+            echo -e "${YELLOW}Note:${NC} Package is still installed until container restart"
+            ;;
+        pip)
+            jq "del(.pip_packages[] | select(. == \"$pkg_name\"))" "$PERSIST_CONFIG" > "${PERSIST_CONFIG}.tmp"
+            mv "${PERSIST_CONFIG}.tmp" "$PERSIST_CONFIG"
+            echo -e "${GREEN}-${NC} Removed '$pkg_name' from persistent pip packages"
+            echo -e "${YELLOW}Note:${NC} Package is still installed until container restart"
+            ;;
+        *)
+            echo -e "${RED}Error:${NC} Unknown package type '$pkg_type'"
+            echo "Usage: persist-install remove <apk|pip> <package>"
+            exit 1
+            ;;
+    esac
+}
+
+# Main command handler
+main() {
+    local command="${1:-help}"
+    shift || true
+
+    case "$command" in
+        apk)
+            install_apk "$@"
+            ;;
+        pip)
+            install_pip "$@"
+            ;;
+        list)
+            list_packages
+            ;;
+        remove)
+            remove_package "$@"
+            ;;
+        help|--help|-h)
+            show_help
+            ;;
+        *)
+            echo -e "${RED}Error:${NC} Unknown command '$command'"
+            echo ""
+            show_help
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Implement persistent APK and pip package management that survives container restarts. Users can install packages via:

- persist-install command (persist-install apk vim htop)
- Add-on config options (persistent_apk_packages, persistent_pip_packages)

Packages are automatically reinstalled on container startup. Thanks to the contribution from @ESJavadex!

Closes #32