### PR TITLE
Update to fix PEP-0668

### DIFF
--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -165,7 +165,7 @@ install_persistent_packages() {
     if [ -n "$pip_packages" ]; then
         bashio::log.info "Installing persistent pip packages: $pip_packages"
         # shellcheck disable=SC2086
-        if pip3 install --no-cache-dir $pip_packages; then
+        if pip3 install --break-system-packages --no-cache-dir $pip_packages; then
             bashio::log.info "pip packages installed successfully"
         else
             bashio::log.warning "Some pip packages failed to install"

--- a/claude-terminal/scripts/persist-install.sh
+++ b/claude-terminal/scripts/persist-install.sh
@@ -131,7 +131,7 @@ install_pip() {
     echo -e "${BLUE}Installing pip packages:${NC} ${packages[*]}"
 
     # Install packages
-    if pip3 install --no-cache-dir "${packages[@]}"; then
+    if pip3 install --break-system-packages --no-cache-dir "${packages[@]}"; then
         echo -e "${GREEN}Installation successful!${NC}"
 
         # Add to persistence config


### PR DESCRIPTION
-  Python 3.11+ on Alpine/Debian enforces https://peps.python.org/pep-0668/ which blocks system-wide pip 
-  installs The --break-system-packages flag explicitly overrides this protection 
- This is safe in a container environment since the addon container is isolated and disposable