### PR TITLE
feat: Switch to native Claude Code installer

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### 🔄 Changed
+- **Native Claude Code Installation**: Switched from npm package to official native installer
+  - Uses `curl -fsSL https://claude.ai/install.sh | bash` instead of `npm install -g @anthropic-ai/claude-code`
+  - Native binary provides automatic background updates from Anthropic
+  - Faster startup (no Node.js interpreter overhead)
+  - Claude binary symlinked to `/usr/local/bin/claude` for easy access
+- **Simplified execution**: All scripts now call `claude` directly instead of `node $(which claude)`
+- **Cleaner Dockerfile**: Removed npm retry/timeout configuration (no longer needed)
+
+### 📦 Notes
+- Node.js and npm remain available as development tools
+- Existing authentication and configuration files are unaffected
+
 ## 1.5.0
 
 ### ✨ New Features

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -25,7 +25,7 @@ Your OAuth credentials are stored in the `/config/claude-config` directory and w
 Claude launches automatically when you open the terminal. You can also start Claude manually with:
 
 ```bash
-node /usr/local/bin/claude
+claude
 ```
 
 ### Common Commands
@@ -49,7 +49,7 @@ The terminal starts directly in your `/config` directory, giving you immediate a
 
 ## Troubleshooting
 
-- If Claude doesn't start automatically, try running `node /usr/local/bin/claude -i` manually
+- If Claude doesn't start automatically, try running `claude -i` manually
 - If you see permission errors, try restarting the add-on
 - If you have authentication issues, try logging out and back in
 - Check the add-on logs for any error messages

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -1,14 +1,13 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
-# Install packages in a single layer to minimize image size
-# Add retry logic for npm installation to handle network issues
+# Install system packages and development tools
 RUN apk add --no-cache \
-    nodejs \
-    npm \
     bash \
     curl \
     nano \
+    nodejs \
+    npm \
     python3 \
     py3-pip \
     py3-requests \
@@ -20,20 +19,12 @@ RUN apk add --no-cache \
     wget \
     jq \
     tree \
-    yq \
-    && (npm config set registry https://registry.npmjs.org/ || true) \
-    && (npm config set fetch-retries 3 || true) \
-    && (npm config set fetch-retry-mintimeout 20000 || true) \
-    && (npm config set fetch-retry-maxtimeout 120000 || true) \
-    && (npm config set fetch-timeout 300000 || true) \
-    && for i in 1 2 3; do \
-        echo "Attempt $i: Installing Claude Code CLI..." && \
-        npm install -g @anthropic-ai/claude-code@latest && \
-        echo "Successfully installed Claude Code CLI" && \
-        break || \
-        (echo "Attempt $i failed, retrying in 10 seconds..." && sleep 10); \
-    done \
-    && npm cache clean --force
+    yq
+
+# Install Claude Code CLI using native installer
+# The installer places the binary in ~/.local/bin
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && ln -sf /root/.local/bin/claude /usr/local/bin/claude
 
 # Create directory for Claude configuration and set working directory
 RUN mkdir -p /config/claude-config

--- a/claude-terminal/README.md
+++ b/claude-terminal/README.md
@@ -19,7 +19,7 @@ This add-on provides a web-based terminal interface with Claude Code CLI pre-ins
 
 - **Web Terminal Interface**: Access Claude through a browser-based terminal using ttyd
 - **Auto-Launch**: Claude starts automatically when you open the terminal
-- **Latest Claude Code CLI**: Pre-installed with Anthropic's official CLI (@latest)
+- **Native Claude Code CLI**: Pre-installed using Anthropic's official native installer with automatic updates
 - **No Configuration Needed**: Uses OAuth authentication for easy setup
 - **Direct Config Access**: Terminal starts in your `/config` directory for immediate access to all Home Assistant files
 - **Home Assistant Integration**: Access directly from your dashboard
@@ -161,6 +161,11 @@ test-endpoint    # Test web endpoint availability
 For detailed usage instructions, see the [documentation](DOCS.md).
 
 ## Version History
+
+### Unreleased - Native Installation
+- **Native Claude Code Installation**: Switched to official native installer
+- Automatic background updates from Anthropic
+- Faster startup without Node.js interpreter overhead
 
 ### v1.5.0 (Current) - Persistent Packages
 - **Persistent Package Management**: Install APK and pip packages that survive restarts

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -219,7 +219,7 @@ get_claude_launch_command() {
     
     if [ "$auto_launch_claude" = "true" ]; then
         # Original behavior: auto-launch Claude directly
-        echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && node \$(which claude)"
+        echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && claude"
     else
         # New behavior: show interactive session picker
         if [ -f /usr/local/bin/claude-session-picker ]; then
@@ -227,7 +227,7 @@ get_claude_launch_command() {
         else
             # Fallback if session picker is missing
             bashio::log.warning "Session picker not found, falling back to auto-launch"
-            echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && node \$(which claude)"
+            echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && claude"
         fi
     fi
 }

--- a/claude-terminal/scripts/claude-session-picker.sh
+++ b/claude-terminal/scripts/claude-session-picker.sh
@@ -44,19 +44,19 @@ get_user_choice() {
 launch_claude_new() {
     echo "🚀 Starting new Claude session..."
     sleep 1
-    exec node "$(which claude)"
+    exec claude
 }
 
 launch_claude_continue() {
     echo "⏩ Continuing most recent conversation..."
     sleep 1
-    exec node "$(which claude)" -c
+    exec claude -c
 }
 
 launch_claude_resume() {
     echo "📋 Opening conversation list for selection..."
     sleep 1
-    exec node "$(which claude)" -r
+    exec claude -r
 }
 
 launch_claude_custom() {
@@ -73,7 +73,7 @@ launch_claude_custom() {
         echo "🚀 Running: claude $custom_args"
         sleep 1
         # Use eval to properly handle quoted arguments
-        eval "exec node \$(which claude) $custom_args"
+        eval "exec claude $custom_args"
     fi
 }
 


### PR DESCRIPTION
## Summary
- Replace npm package installation with Anthropic's official native installer
- Use `curl -fsSL https://claude.ai/install.sh | bash` for Claude Code installation
- Symlink native binary to `/usr/local/bin/claude` for PATH accessibility
- Update all scripts to call `claude` directly instead of `node $(which claude)`
- Remove npm retry/timeout configuration (no longer needed)

## Benefits
- **Automatic updates**: Native installer provides background updates from Anthropic
- **Faster startup**: No Node.js interpreter overhead
- **Simpler execution**: Direct binary invocation

## Test plan
- [x] Build Docker image locally
- [x] Verify `claude --version` works inside container
- [x] Test session picker menu options launch Claude correctly
- [x] Test bash shell option can run `claude` manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)