### PR TITLE
fix: resolve native install path mismatch when HOME=/data/home (v1.6.1)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.6.1
+
+### 🐛 Bug Fix - Native Install Path Mismatch
+- **Fixed "installMethod is native, but directory does not exist" error**: Claude binary now available at `$HOME/.local/bin/claude` at runtime
+  - **Root cause**: Native installer places Claude at `/root/.local/bin/claude` during Docker build, but at runtime `HOME=/data/home`, so Claude's self-check looks in `/data/home/.local/bin/claude` which didn't exist
+  - **Solution**: Symlink created from `/data/home/.local/bin/claude` → `/root/.local/bin/claude` on startup
+  - **Result**: Claude native binary resolves correctly regardless of HOME directory change
+  - Ref: [ESJavadex/claude-code-ha#3](https://github.com/ESJavadex/claude-code-ha/issues/3)
+
 ## 1.6.0 - 2026-01-26
 
 ### 🔄 Changed

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Terminal interface for Anthropic's Claude Code CLI with persistent auth and packages"
-version: "1.6.0"
+version: "1.6.1"
 slug: "claude_terminal"
 init: false
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -24,6 +24,18 @@ init_environment() {
     # Set permissions
     chmod 755 "$data_home" "$config_dir" "$cache_dir" "$state_dir" "$claude_config_dir"
 
+    # Ensure Claude native binary is available at $HOME/.local/bin/claude
+    # The native installer places it at /root/.local/bin/claude during Docker build,
+    # but at runtime HOME=/data/home, so Claude's self-check looks in /data/home/.local/bin/
+    local native_bin_dir="$data_home/.local/bin"
+    if [ ! -d "$native_bin_dir" ]; then
+        mkdir -p "$native_bin_dir"
+    fi
+    if [ -f /root/.local/bin/claude ] && [ ! -f "$native_bin_dir/claude" ]; then
+        ln -sf /root/.local/bin/claude "$native_bin_dir/claude"
+        bashio::log.info "  - Claude native binary linked: $native_bin_dir/claude"
+    fi
+
     # Set XDG and application environment variables
     export HOME="$data_home"
     export XDG_CONFIG_HOME="$config_dir"


### PR DESCRIPTION
## Summary
- **Fixed "installMethod is native, but directory does not exist" error** introduced in v1.6.0 with the native installer migration
- The native installer places Claude at `/root/.local/bin/claude` during Docker build, but at runtime `HOME=/data/home`, so Claude's self-check looks in `/data/home/.local/bin/claude` which doesn't exist
- Creates a symlink from `/data/home/.local/bin/claude` → `/root/.local/bin/claude` on startup

Ref: [ESJavadex/claude-code-ha#3](https://github.com/ESJavadex/claude-code-ha/issues/3) — reported by @jokerigno

## Test plan
- [ ] Build the add-on with `docker build`
- [ ] Start the container and verify no "installMethod is native" error appears
- [ ] Verify `ls -la /data/home/.local/bin/claude` shows the symlink
- [ ] Verify `claude --version` works from ttyd terminal
- [ ] Verify Claude sessions remain stable without disconnections

🤖 Generated with [Claude Code](https://claude.com/claude-code)