### PR TITLE
fix: Code review workflow fails on fork PRs due to missing OIDC token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     


### PR DESCRIPTION
## Summary

- **`pull_request` → `pull_request_target`**: GitHub Actions does not provide OIDC tokens for `pull_request` events from forks. The `claude-code-action` requires an OIDC token to authenticate, causing the review workflow to fail on every fork PR with: `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?`. Switching to `pull_request_target` runs the workflow in the base repo's context, which has access to OIDC tokens and secrets. This is safe because the action reviews the PR via `gh pr diff` / `gh pr view` rather than executing code from the fork.
- **`pull-requests: read` → `pull-requests: write`**: The action uses `gh pr comment` to post its review, which requires write permission.

## Test plan

- [ ] Open a PR from a fork and verify the Claude Code Review workflow passes
- [ ] Verify the review comment is posted on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)