### PR TITLE
fix: use npm to install Claude Code on Alpine/musl aarch64

### DIFF
--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -22,10 +22,9 @@ RUN apk add --no-cache \
     tmux \
     yq
 
-# Install Claude Code CLI using native installer
-# The installer places the binary in ~/.local/bin
-RUN curl -fsSL https://claude.ai/install.sh | bash \
-    && ln -sf /root/.local/bin/claude /usr/local/bin/claude
+# Install Claude Code CLI via npm (native installer fails on Alpine/musl aarch64
+# due to missing posix_getdents symbol in pre-built binaries)
+RUN npm install -g @anthropic-ai/claude-code
 
 # Create directory for Claude configuration and set working directory
 RUN mkdir -p /config/claude-config


### PR DESCRIPTION
## Problem

The 1.8.0 build fails on aarch64 HA installations with:

```
Error relocating /root/.claude/downloads/claude-2.1.74-linux-arm64-musl: posix_getdents: symbol not found
```

The native installer downloads a pre-built musl binary that uses `posix_getdents`, which is not available in the Alpine musl version used by HA add-on base images.

## Fix

Replace the native installer with `npm install -g @anthropic-ai/claude-code`, since `nodejs` and `npm` are already installed in the Dockerfile. This uses the existing Node.js runtime instead of the pre-built musl binary, which works correctly on Alpine aarch64.

## Tested on

- Home Assistant OS on aarch64 (Raspberry Pi / similar)
- Add-on version 1.7.0 uses npm-based install and works fine — this restores that behaviour