### PR TITLE
fix: add --index-strategy unsafe-best-match to uvx for ha-mcp

### DIFF
--- a/claude-terminal/scripts/setup-ha-mcp.sh
+++ b/claude-terminal/scripts/setup-ha-mcp.sh
@@ -45,13 +45,13 @@ configure_ha_mcp_server() {
     if claude mcp add home-assistant \
         --env "HOMEASSISTANT_URL=http://supervisor/core" \
         --env "HOMEASSISTANT_TOKEN=${SUPERVISOR_TOKEN}" \
-        -- uvx ha-mcp@3.5.1; then
+        -- uvx --index-strategy unsafe-best-match ha-mcp@3.5.1; then
         bashio::log.info "ha-mcp configured successfully!"
         bashio::log.info "Claude Code now has access to Home Assistant via MCP"
         bashio::log.info "Available tools: entity control, automations, scripts, history, and more"
     else
         bashio::log.warning "Failed to configure ha-mcp - continuing without MCP integration"
-        bashio::log.warning "You can manually run: claude mcp add home-assistant --env HOMEASSISTANT_URL=http://supervisor/core --env HOMEASSISTANT_TOKEN=\$SUPERVISOR_TOKEN -- uvx ha-mcp@3.5.1"
+        bashio::log.warning "You can manually run: claude mcp add home-assistant --env HOMEASSISTANT_URL=http://supervisor/core --env HOMEASSISTANT_TOKEN=\$SUPERVISOR_TOKEN -- uvx --index-strategy unsafe-best-match ha-mcp@3.5.1"
     fi
 }
 


### PR DESCRIPTION
## Problem

`uvx ha-mcp@3.5.1` fails to start on Python 3.12 because the HA wheels index (`wheels.home-assistant.io/musllinux-index`) only provides `pydantic-core` wheels for CPython 3.13. The add-on runs Python 3.12, so `uv` cannot resolve the dependency chain:

```
ha-mcp → fastmcp ≥ 2.11.0 → pydantic ≥ 2.11.7 → pydantic-core 2.33.2 (cp313 only on HA index)
```

Result: the MCP server fails on every session start with `✗ Failed to connect`.

## Fix

Add `--index-strategy unsafe-best-match` to the `uvx` invocation in `setup-ha-mcp.sh`. This tells `uv` to fall back to PyPI when the HA wheels index does not have a compatible wheel for the running Python version.

## Changes

`claude-terminal/scripts/setup-ha-mcp.sh`:
- `uvx ha-mcp@3.5.1` → `uvx --index-strategy unsafe-best-match ha-mcp@3.5.1`
- Same fix applied to the manual fallback hint in the warning message

## Tested on

- Add-on v2.2.0, Python 3.12.12, Alpine Linux (haos kernel 6.12.67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)