### PR TITLE
security: Disable remote access port 7681 by default

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.1
+
+### 🛠️ Configuration
+- Disable remote access port 7681 by default
+
+### 🔒 Security Note
+The default configuration enabled unauthenticated access on the local network. For users who have not customized the port setting, direct access on port 7681 is now disabled by default. Access through Home Assistant (ingress) is not affected by this change. Users who need direct port access can re-enable it in the add-on configuration.
+
 ## 2.2.0
 
 ### ✨ New Features

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Terminal interface for Anthropic's Claude Code CLI with persistent auth and packages"
-version: "2.2.0"
+version: "2.2.1"
 slug: "claude_terminal"
 init: false
 
@@ -23,7 +23,7 @@ panel_admin: true
 
 # Port configuration
 ports:
-  7681/tcp: 7681
+  7681/tcp: null
 ports_description:
   7681/tcp: "Web terminal (not required for ingress)"
 


### PR DESCRIPTION
The default configuration exposed unauthenticated access on the local network. Port 7681 is now disabled by default; ingress access through Home Assistant is unaffected.