### PR TITLE
ci: Fix trivy-action tag reference to use v prefix

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,7 +35,7 @@ jobs:
             BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.21
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: scan/claude-terminal:latest
           format: table
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Run Trivy (SARIF for Security tab)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: scan/claude-terminal:latest
           format: sarif


### PR DESCRIPTION
The aquasecurity/trivy-action repo publishes tags as v0.28.0, not 0.28.0.
Scheduled Security Scan was failing in ~3s with "unable to find version
0.28.0" before any scan could run.