### PR TITLE
ci: Bump trivy-action to v0.35.0 (fix setup-trivy tag removal)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,7 +35,7 @@ jobs:
             BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.21
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: scan/claude-terminal:latest
           format: table
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Run Trivy (SARIF for Security tab)
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: scan/claude-terminal:latest
           format: sarif


### PR DESCRIPTION
`trivy-action@v0.28.0` still failed because its composite references `aquasecurity/setup-trivy@v0.2.1`, which has been removed upstream (only `v0.2.6` remains as a live tag). Bumping to `v0.35.0`, which pins `setup-trivy` by commit SHA, makes it immune to upstream tag churn.

## Test plan
- [ ] Security Scan workflow triggers on this PR
- [ ] `Run Trivy vulnerability scanner` step completes without "unable to find version" error
- [ ] SARIF upload succeeds