### PR TITLE
feat: add configurable working directory and Claude data path

### DIFF
--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -32,12 +32,18 @@ options:
   auto_launch_claude: true
   ha_smart_context: true
   enable_ha_mcp: true
+  working_directory: "/config"
+  prompt_working_directory: false
+  claude_data_path: ""
   persistent_apk_packages: []
   persistent_pip_packages: []
 schema:
   auto_launch_claude: bool?
   ha_smart_context: bool?
   enable_ha_mcp: bool?
+  working_directory: str?
+  prompt_working_directory: bool?
+  claude_data_path: str?
   persistent_apk_packages:
     - str
   persistent_pip_packages:

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -6,17 +6,25 @@ set -o pipefail
 
 # Initialize environment for Claude Code CLI using /data (HA best practice)
 init_environment() {
-    # Use /data exclusively - guaranteed writable by HA Supervisor
-    local data_home="/data/home"
-    local config_dir="/data/.config"
-    local cache_dir="/data/.cache"
-    local state_dir="/data/.local/state"
-    local claude_config_dir="/data/.config/claude"
+    # Allow user to override the data base directory (e.g. /config/.claude-data)
+    # so that Claude sessions/config are accessible via the HA /config volume.
+    # Defaults to /data (HA Supervisor guaranteed-writable volume).
+    local data_base
+    data_base=$(bashio::config 'claude_data_path' '')
+    if [ -z "$data_base" ] || [ "$data_base" = "null" ]; then
+        data_base="/data"
+    fi
 
-    bashio::log.info "Initializing Claude Code environment in /data..."
+    local data_home="${data_base}/home"
+    local config_dir="${data_base}/.config"
+    local cache_dir="${data_base}/.cache"
+    local state_dir="${data_base}/.local/state"
+    local claude_config_dir="${data_base}/.config/claude"
+
+    bashio::log.info "Initializing Claude Code environment in ${data_base}..."
 
     # Create all required directories
-    if ! mkdir -p "$data_home" "$config_dir/claude" "$cache_dir" "$state_dir" "/data/.local"; then
+    if ! mkdir -p "$data_home" "$config_dir/claude" "$cache_dir" "$state_dir" "${data_base}/.local"; then
         bashio::log.error "Failed to create directories in /data"
         exit 1
     fi
@@ -29,11 +37,11 @@ init_environment() {
     export XDG_CONFIG_HOME="$config_dir"
     export XDG_CACHE_HOME="$cache_dir"
     export XDG_STATE_HOME="$state_dir"
-    export XDG_DATA_HOME="/data/.local/share"
-    
+    export XDG_DATA_HOME="${data_base}/.local/share"
+
     # Claude-specific environment variables
     export ANTHROPIC_CONFIG_DIR="$claude_config_dir"
-    export ANTHROPIC_HOME="/data"
+    export ANTHROPIC_HOME="$data_base"
 
     # Migrate any existing authentication files from legacy locations
     migrate_legacy_auth_files "$claude_config_dir"
@@ -234,6 +242,16 @@ setup_session_picker() {
         fi
     fi
 
+    # Setup working directory picker script
+    if [ -f "/opt/scripts/pick-working-dir.sh" ]; then
+        if cp /opt/scripts/pick-working-dir.sh /usr/local/bin/pick-working-dir; then
+            chmod +x /usr/local/bin/pick-working-dir
+            bashio::log.info "Working directory picker installed successfully"
+        else
+            bashio::log.warning "Failed to copy pick-working-dir script"
+        fi
+    fi
+
     # Write add-on version for welcome script to read (avoids bashio dependency in ttyd)
     bashio::addon.version > /opt/scripts/addon-version 2>/dev/null || echo "unknown" > /opt/scripts/addon-version
 }
@@ -270,6 +288,24 @@ get_claude_launch_command() {
     # Get configuration value, default to true for backward compatibility
     auto_launch_claude=$(bashio::config 'auto_launch_claude' 'true')
 
+    # Get working directory, default to /config
+    local working_dir
+    working_dir=$(bashio::config 'working_directory' '/config')
+    if [ -z "$working_dir" ] || [ "$working_dir" = "null" ]; then
+        working_dir="/config"
+    fi
+
+    # If prompt_working_directory is enabled, source the picker script so the
+    # user can confirm or change the dir on each session open.
+    local prompt_dir
+    prompt_dir=$(bashio::config 'prompt_working_directory' 'false')
+    local cd_prefix
+    if [ "$prompt_dir" = "true" ] && [ -f /usr/local/bin/pick-working-dir ]; then
+        cd_prefix=". /usr/local/bin/pick-working-dir '${working_dir}'; "
+    else
+        cd_prefix="cd '${working_dir}' 2>/dev/null || cd /config; "
+    fi
+
     # Prepend welcome banner if available (runs inside ttyd, user-visible)
     local welcome_prefix=""
     if [ -f /usr/local/bin/welcome ]; then
@@ -278,16 +314,16 @@ get_claude_launch_command() {
 
     if [ "$auto_launch_claude" = "true" ]; then
         # Use tmux for session persistence - attach to existing or create new
-        echo "${welcome_prefix}tmux new-session -A -s claude 'claude'"
+        echo "${welcome_prefix}${cd_prefix}tmux new-session -A -s claude 'claude'"
     else
         # Session picker manages its own tmux sessions internally,
         # so do NOT wrap it in tmux (that would cause nested tmux errors)
         if [ -f /usr/local/bin/claude-session-picker ]; then
-            echo "${welcome_prefix}/usr/local/bin/claude-session-picker"
+            echo "${welcome_prefix}${cd_prefix}/usr/local/bin/claude-session-picker"
         else
             # Fallback if session picker is missing
             bashio::log.warning "Session picker not found, falling back to auto-launch"
-            echo "${welcome_prefix}tmux new-session -A -s claude 'claude'"
+            echo "${welcome_prefix}${cd_prefix}tmux new-session -A -s claude 'claude'"
         fi
     fi
 }

--- a/claude-terminal/scripts/pick-working-dir.sh
+++ b/claude-terminal/scripts/pick-working-dir.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Prompt the user to confirm or change the working directory on each session start.
+# Saves the last-used dir so it appears as the default next time.
+#
+# Usage: source this script (do NOT run it as a subprocess — cd must affect the caller)
+#   . /usr/local/bin/pick-working-dir "/config"
+
+_pwd_default="${1:-/config}"
+_pwd_state="${ANTHROPIC_HOME}/last-working-dir"
+
+# Load last used dir, fall back to configured default
+if [ -f "$_pwd_state" ]; then
+    _pwd_last=$(cat "$_pwd_state")
+else
+    _pwd_last="$_pwd_default"
+fi
+
+printf "\nWorking directory [%s]: " "$_pwd_last"
+read -r _pwd_chosen
+_pwd_chosen="${_pwd_chosen:-$_pwd_last}"
+
+# Persist choice
+echo "$_pwd_chosen" > "$_pwd_state"
+
+if ! cd "$_pwd_chosen" 2>/dev/null; then
+    printf "Directory '%s' not found, falling back to /config\n" "$_pwd_chosen"
+    cd /config
+fi
+
+unset _pwd_default _pwd_state _pwd_last _pwd_chosen


### PR DESCRIPTION
## Summary

Three new options, all backwards-compatible (defaults preserve existing behaviour):

- **`working_directory`** — directory Claude starts in (default `/config`). Useful if your work lives in a subdirectory like `/config/ai_repo`.
- **`prompt_working_directory`** — when `true`, prompts you to confirm or change the working directory on every session open, showing the last-used path as the default.
- **`claude_data_path`** — relocate `~/.claude` session/config data out of `/data` (container-only, not visible to ha filesystem or over SMB) into a user-specified path such as `/config/.claude`. Makes sessions accessible over SMB and portable across HA migrations or reinstalls.

Adds `scripts/pick-working-dir.sh` which handles the interactive directory prompt and persists the last choice to `$ANTHROPIC_HOME/last-working-dir`.

## Motivation

Currently the addon stores all Claude data under `/data`, which is the container's private persistent volume. This means session history and project files are invisible over SMB and lost if you migrate or reinstall HA. Moving data to `/config` solves both problems.

## Test notes

Tested on 2.2.x with `claude_data_path: /config/.claude` and `working_directory: /config/ai_repo`. A few things discovered during testing worth noting for reviewers:

- All environment variables (`HOME`, `XDG_*`, `ANTHROPIC_*`) are derived from `claude_data_path` so they stay consistent — no hardcoded `/data` paths remain
- The `last-working-dir` state file is stored under `$ANTHROPIC_HOME` so it persists across restarts when `claude_data_path` points to `/config`

## Test plan

- [ ] Addon starts normally with no options set (defaults to `/config`, uses `/data` for Claude data)
- [ ] Setting `working_directory: /config/ai_repo` lands Claude in that directory on open
- [ ] Enabling `prompt_working_directory: true` shows prompt; Enter confirms last-used dir; choice persists across restarts
- [ ] Setting `claude_data_path: /config/.claude` creates directory structure there and Claude stores sessions/config under it
- [ ] Sessions and auth survive addon restart when `claude_data_path` is under `/config`
- [ ] Existing auth files still migrate correctly when `claude_data_path` is set