### PR TITLE
Feature/ssh server

### DIFF
--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -24,20 +24,29 @@ panel_admin: true
 # Port configuration
 ports:
   7681/tcp: null
+  2222/tcp: null
 ports_description:
   7681/tcp: "Web terminal (not required for ingress)"
+  2222/tcp: "SSH server (optional, enable in config)"
 
 # Add-on configuration options
 options:
   auto_launch_claude: true
   ha_smart_context: true
   enable_ha_mcp: true
+  enable_ssh: false
+  ssh_port: 2222
+  ssh_authorized_keys: []
   persistent_apk_packages: []
   persistent_pip_packages: []
 schema:
   auto_launch_claude: bool?
   ha_smart_context: bool?
   enable_ha_mcp: bool?
+  enable_ssh: bool?
+  ssh_port: int?
+  ssh_authorized_keys:
+    - str
   persistent_apk_packages:
     - str
   persistent_pip_packages:

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -383,11 +383,17 @@ setup_ssh() {
     local auth_keys_file="${ssh_user_dir}/authorized_keys"
     : > "$auth_keys_file"
 
-    if bashio::config.has_value 'ssh_authorized_keys'; then
-        local keys
-        keys=$(bashio::config 'ssh_authorized_keys')
-        echo "$keys" | jq -r '.[]' 2>/dev/null >> "$auth_keys_file" || true
+    local keys_raw
+    keys_raw=$(bashio::config 'ssh_authorized_keys' 2>/dev/null || echo "")
+    if [ -n "$keys_raw" ]; then
+        # bashio returns JSON array for multi-value or raw string for single value
+        if echo "$keys_raw" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "$keys_raw" | jq -r '.[]' >> "$auth_keys_file"
+        else
+            echo "$keys_raw" >> "$auth_keys_file"
+        fi
     fi
+    bashio::log.info "SSH authorized keys written: $(wc -l < "$auth_keys_file" | tr -d ' ') key(s)"
     chmod 600 "$auth_keys_file"
 
     # Write minimal sshd config

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -343,6 +343,69 @@ run_health_check() {
     fi
 }
 
+# Optionally start an SSH server for remote access (VS Code, terminal, etc.)
+setup_ssh() {
+    local enable_ssh
+    enable_ssh=$(bashio::config 'enable_ssh' 'false')
+
+    if [ "$enable_ssh" != "true" ]; then
+        bashio::log.info "SSH server disabled"
+        return 0
+    fi
+
+    local ssh_port
+    ssh_port=$(bashio::config 'ssh_port' '2222')
+
+    bashio::log.info "Setting up SSH server on port ${ssh_port}..."
+
+    # Install openssh server if not already present
+    if ! command -v sshd &>/dev/null; then
+        apk add --no-cache openssh || { bashio::log.error "Failed to install openssh"; return 1; }
+    fi
+
+    # Persist host keys in data dir so they survive container restarts
+    local host_key_dir="/data/ssh"
+    mkdir -p "$host_key_dir"
+    chmod 700 "$host_key_dir"
+
+    for key_type in rsa ed25519; do
+        local key_file="${host_key_dir}/ssh_host_${key_type}_key"
+        if [ ! -f "$key_file" ]; then
+            ssh-keygen -t "$key_type" -f "$key_file" -N "" -q
+            bashio::log.info "Generated SSH host key: ${key_file}"
+        fi
+    done
+
+    # Write authorized keys from config
+    local ssh_user_dir="/data/home/.ssh"
+    mkdir -p "$ssh_user_dir"
+    chmod 700 "$ssh_user_dir"
+    local auth_keys_file="${ssh_user_dir}/authorized_keys"
+    : > "$auth_keys_file"
+
+    if bashio::config.has_value 'ssh_authorized_keys'; then
+        local keys
+        keys=$(bashio::config 'ssh_authorized_keys')
+        echo "$keys" | jq -r '.[]' 2>/dev/null >> "$auth_keys_file" || true
+    fi
+    chmod 600 "$auth_keys_file"
+
+    # Write minimal sshd config
+    cat > /etc/ssh/sshd_config <<EOF
+Port ${ssh_port}
+HostKey ${host_key_dir}/ssh_host_rsa_key
+HostKey ${host_key_dir}/ssh_host_ed25519_key
+AuthorizedKeysFile ${auth_keys_file}
+PubkeyAuthentication yes
+PasswordAuthentication no
+PermitRootLogin yes
+EOF
+
+    # Start sshd in background
+    /usr/sbin/sshd || { bashio::log.error "Failed to start sshd"; return 1; }
+    bashio::log.info "SSH server started on port ${ssh_port}"
+}
+
 # Setup ha-mcp (Home Assistant MCP Server) for Claude Code integration
 setup_ha_mcp() {
     if [ -f "/opt/scripts/setup-ha-mcp.sh" ]; then
@@ -368,6 +431,7 @@ main() {
     setup_session_picker
     install_persistent_packages
     generate_ha_context
+    setup_ssh
     setup_ha_mcp
     start_web_terminal
 }

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -364,7 +364,7 @@ setup_ssh() {
     fi
 
     # Persist host keys in data dir so they survive container restarts
-    local host_key_dir="/data/ssh"
+    local host_key_dir="${ANTHROPIC_HOME}/ssh"
     mkdir -p "$host_key_dir"
     chmod 700 "$host_key_dir"
 
@@ -377,7 +377,7 @@ setup_ssh() {
     done
 
     # Write authorized keys from config
-    local ssh_user_dir="/data/home/.ssh"
+    local ssh_user_dir="${HOME}/.ssh"
     mkdir -p "$ssh_user_dir"
     chmod 700 "$ssh_user_dir"
     local auth_keys_file="${ssh_user_dir}/authorized_keys"


### PR DESCRIPTION
## Summary

Adds an opt-in SSH server so you can connect to the addon container directly from VS Code Remote, a Mac terminal, or any SSH client — without going through the web terminal.

Three new options:

- **`enable_ssh`** — toggle, default `false`
- **`ssh_port`** — port to listen on, default `2222` (also exposed in addon port mappings)
- **`ssh_authorized_keys`** — list of public keys; password authentication is disabled

## Usage

1. Enable `enable_ssh: true` in addon config
2. Paste your public key (`cat ~/.ssh/id_ed25519.pub`) into `ssh_authorized_keys`
3. Map port 2222 in the addon's Network settings
4. Connect: `ssh root@<ha-ip> -p 2222`
5. Attach to the running Claude session: `ssh root@<ha-ip> -p 2222 -t "tmux attach -t claude"`

## Implementation notes

- SSH host keys are persisted under `$ANTHROPIC_HOME/ssh/` (which respects `claude_data_path` if set) so your SSH client won't warn about key changes on container restart
- `authorized_keys` is written to `$HOME/.ssh/authorized_keys` — correctly follows `claude_data_path` if configured
- `bashio::config` returns a raw string for single-item lists rather than a JSON array — the key writing handles both cases
- Password authentication is disabled; public key only

## Test plan

- [ ] Addon starts normally with `enable_ssh: false` (default) — no sshd running
- [ ] Enabling SSH with a valid public key allows connection on configured port
- [ ] Host keys persist across container restarts (no SSH client key-change warnings after first connect)
- [ ] Password authentication is rejected
- [ ] `tmux attach -t claude` over SSH attaches to the running Claude session
- [ ] Works correctly alongside `claude_data_path` set to a non-default path