### PR TITLE
feat: Keep Claude Code current via persistent native install in /data

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.3.3
+
+### 🐛 Bug Fixes
+- **Fixed "WebSocket not connected" in ha-mcp template rendering**: Bumped the pinned ha-mcp from 3.5.1 (four major versions behind) to 7.9.0. REST-based tools worked on 3.5.1, but WebSocket-based tools like `ha_eval_template` failed; the WebSocket path through the Supervisor proxy was verified healthy, isolating the bug to the old ha-mcp client. ha-mcp 7.9.0 exposes 77 tools (verified via MCP `tools/list`)
+
+### ✨ New Features
+- **`ha_mcp_version` option** (default `"7.9.0"`): The ha-mcp version is now configurable from the add-on options, so future bumps don't require an add-on update
+
+### 🛠️ Technical Details
+- Every ha-mcp release after 3.5.1 requires CPython 3.13 exactly (`>=3.13,<3.14`), which no Alpine release ships (3.21–3.23 have 3.12, 3.24 has 3.14) — this is why the pin was stuck at 3.5.1
+- uv now comes from the official installer (0.11.26) instead of the outdated Alpine package (0.5.31), because only recent uv can download managed musl Python builds; `uvx --python 3.13` provisions CPython 3.13 into `/data` (persistent)
+- The uv caches are pre-warmed in the background at startup so the first MCP connection doesn't hit the client startup timeout
+- armv7 has no managed musl Python builds and stays on ha-mcp 3.5.1 (the last release supporting the system Python)
+
 ## 2.3.2
 
 ### 🐛 Bug Fixes

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.2
+
+### 🐛 Bug Fixes
+- Fixed welcome banner border misalignment on the version line (padding was 3 columns short)
+
 ## 2.3.1
 
 ### ✨ New Features

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.3.0
+## 2.3.1
 
 ### ✨ New Features
 - **Claude Code stays up to date** (`claude_auto_update`, enabled by default): The add-on now installs the official native Claude Code build into `/data` on first startup and checks for updates in the background on every restart
@@ -8,10 +8,14 @@
   - Native install is used on amd64/aarch64; armv7 (no native builds) and offline starts fall back to the bundled npm copy
   - Set `claude_auto_update: false` to keep using the bundled version
 - **Startup hooks**: Shell scripts in `/data/init.d/*.sh` are sourced during startup, giving users a persistent way to customize the ephemeral container (environment variables, `PATH`, tool setup) — following the same philosophy as `persistent_apk_packages`
+- **`dangerously_skip_permissions` option** (disabled by default): Launch Claude with `--dangerously-skip-permissions` so it never prompts before running tools. Sets `IS_SANDBOX=1`, which Claude Code requires before accepting the flag as root. Read the security note in the documentation before enabling
+- **`claude_extra_args` option**: Extra command-line flags appended to every Claude launch (auto-launch and session picker), e.g. `--continue` or `--model claude-sonnet-5`
+- **Welcome banner shows the Claude Code version** and whether it is the self-updating native install or the copy bundled in the image — no shell access needed to verify what is running
 
 ### 🛠️ Technical Details
-- `$HOME/.local/bin` (i.e. `/data/home/.local/bin`) is now prepended to `PATH`, so a persistent native Claude install takes precedence over `/usr/local/bin/claude` everywhere: auto-launch, session picker, auth helper, and MCP setup all invoke `claude` unqualified
+- `$HOME/.local/bin` (i.e. `/data/home/.local/bin`) is now prepended to `PATH`, so a persistent native Claude install takes precedence over the bundled npm copy everywhere: auto-launch, session picker, auth helper, and MCP setup all invoke `claude` unqualified
 - First-time native install probes connectivity first and is capped at 5 minutes; subsequent update checks run in the background and never delay startup
+- The add-on log reports the active binary at startup: `Active Claude Code: /data/home/.local/bin/claude 2.1.201`
 
 ## 2.2.2
 

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.3.0
+
+### ✨ New Features
+- **Claude Code stays up to date** (`claude_auto_update`, enabled by default): The add-on now installs the official native Claude Code build into `/data` on first startup and checks for updates in the background on every restart
+  - The npm copy baked into the image is frozen at whatever version was current when the image was built on your machine; the native install in `/data` persists across restarts and keeps itself current
+  - Native install is used on amd64/aarch64; armv7 (no native builds) and offline starts fall back to the bundled npm copy
+  - Set `claude_auto_update: false` to keep using the bundled version
+- **Startup hooks**: Shell scripts in `/data/init.d/*.sh` are sourced during startup, giving users a persistent way to customize the ephemeral container (environment variables, `PATH`, tool setup) — following the same philosophy as `persistent_apk_packages`
+
+### 🛠️ Technical Details
+- `$HOME/.local/bin` (i.e. `/data/home/.local/bin`) is now prepended to `PATH`, so a persistent native Claude install takes precedence over `/usr/local/bin/claude` everywhere: auto-launch, session picker, auth helper, and MCP setup all invoke `claude` unqualified
+- First-time native install probes connectivity first and is capped at 5 minutes; subsequent update checks run in the background and never delay startup
+
 ## 2.2.2
 
 ### 🐛 Bug Fixes

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -26,6 +26,7 @@ Your OAuth credentials are stored in the `/config/claude-config` directory and w
 |--------|---------|-------------|
 | `auto_launch_claude` | `true` | Automatically start Claude when opening the terminal |
 | `enable_ha_mcp` | `true` | Enable Home Assistant MCP server integration |
+| `ha_mcp_version` | `"7.9.0"` | Version of [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) to run (armv7 is capped at 3.5.1 — newer releases need Python 3.13, unavailable there) |
 | `claude_auto_update` | `true` | Keep Claude Code current via a persistent native install in `/data` |
 | `dangerously_skip_permissions` | `false` | Launch Claude without permission prompts (see security note below) |
 | `claude_extra_args` | `""` | Extra flags appended to every Claude launch, e.g. `--continue` |

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -27,8 +27,44 @@ Your OAuth credentials are stored in the `/config/claude-config` directory and w
 | `auto_launch_claude` | `true` | Automatically start Claude when opening the terminal |
 | `enable_ha_mcp` | `true` | Enable Home Assistant MCP server integration |
 | `claude_auto_update` | `true` | Keep Claude Code current via a persistent native install in `/data` |
+| `dangerously_skip_permissions` | `false` | Launch Claude without permission prompts (see security note below) |
+| `claude_extra_args` | `""` | Extra flags appended to every Claude launch, e.g. `--continue` |
 | `persistent_apk_packages` | `[]` | APK packages to install on every startup |
 | `persistent_pip_packages` | `[]` | Python packages to install on every startup |
+
+### Skipping Permission Prompts
+
+With `dangerously_skip_permissions: true`, Claude is launched with
+`--dangerously-skip-permissions` and will edit files and run commands without
+asking first. Because the add-on runs as root, the option also sets
+`IS_SANDBOX=1`, which Claude Code requires before it accepts the flag for the
+root user.
+
+**Security note:** combined with the Home Assistant MCP integration and the
+`/config` mount, this gives Claude unattended control over your Home Assistant
+configuration and devices. Only enable it if you understand and accept that.
+Claude shows a one-time acceptance dialog on first launch; your acceptance is
+stored in `/data` and persists.
+
+### Extra Launch Flags
+
+`claude_extra_args` is appended to the Claude command used by auto-launch and
+by the session picker's standard modes. Examples: `--continue` to always
+resume the most recent conversation, or `--model claude-sonnet-5` to pin a
+model. Keep it to simple space-separated flags (no quotes).
+
+### Checking Which Claude Code Version Is Running
+
+You don't need shell access to verify the running version:
+
+- The welcome banner shows the Claude Code version and whether it is the
+  native install or the bundled copy.
+- The add-on log (Settings → Add-ons → Claude Terminal → Log) prints
+  `Active Claude Code: <path> <version>` at startup.
+- Inside Claude, `/status` shows the version, and `!` runs shell commands
+  (e.g. `!command -v claude`).
+- For a real shell, set `auto_launch_claude: false` and pick
+  "Drop to bash shell" in the session picker.
 
 ## Keeping Claude Code Up to Date
 

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -26,8 +26,45 @@ Your OAuth credentials are stored in the `/config/claude-config` directory and w
 |--------|---------|-------------|
 | `auto_launch_claude` | `true` | Automatically start Claude when opening the terminal |
 | `enable_ha_mcp` | `true` | Enable Home Assistant MCP server integration |
+| `claude_auto_update` | `true` | Keep Claude Code current via a persistent native install in `/data` |
 | `persistent_apk_packages` | `[]` | APK packages to install on every startup |
 | `persistent_pip_packages` | `[]` | Python packages to install on every startup |
+
+## Keeping Claude Code Up to Date
+
+The container image bundles an npm copy of Claude Code that is frozen at
+whatever version was current when the image was built. Because the Supervisor
+recreates the container filesystem on every restart, updating that copy
+in-place does not survive a restart.
+
+With `claude_auto_update: true` (the default), the add-on instead installs the
+official native Claude Code build into `/data` (which persists across restarts
+and add-on updates) on first startup, and checks for updates in the background
+on every subsequent startup. The native install takes precedence over the
+bundled npm copy, which remains as a fallback for offline starts and for
+architectures without native builds (armv7).
+
+Set `claude_auto_update: false` to stop installing or updating the native
+build. An existing native install in `/data` continues to be used; remove
+`/data/home/.local/bin/claude` (from the terminal: `rm ~/.local/bin/claude`)
+to fall back to the bundled npm copy.
+
+## Startup Hooks
+
+Shell scripts placed in `/data/init.d/` (named `*.sh`) are sourced during
+add-on startup, after packages are installed and before the terminal launches.
+Because `/data` persists across restarts, this is the supported way to
+customize the otherwise ephemeral container — for example exporting
+environment variables, adjusting `PATH`, or pinning a specific Claude Code
+install:
+
+```bash
+# /data/init.d/10-custom-env.sh
+export MY_VARIABLE="value"
+```
+
+Hooks run as root inside the add-on container; a failing hook logs a warning
+but does not prevent startup.
 
 ## Usage
 

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -27,8 +27,12 @@ RUN npm install -g @anthropic-ai/claude-code@latest \
     && npm cache clean --force
 
 # Install uv for running ha-mcp (Python package manager/runner)
-# ha-mcp requires Python 3.13+, uv handles this automatically
-RUN apk add --no-cache uv
+# ha-mcp >=3.6 requires CPython 3.13 exactly, which no Alpine release ships,
+# and Alpine's apk-packaged uv is too old to download managed musl Python
+# builds - so install a recent uv from the official installer instead
+RUN curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.11.26/install.sh \
+    && env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh \
+    && rm /tmp/uv-install.sh
 
 # Create directory for Claude configuration and set working directory
 RUN mkdir -p /config/claude-config

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Terminal with Anthropic's Claude Code CLI, persistent auth, and packages"
-version: "2.3.2"
+version: "2.3.3"
 slug: "claude_terminal"
 init: false
 
@@ -32,6 +32,7 @@ options:
   auto_launch_claude: true
   ha_smart_context: true
   enable_ha_mcp: true
+  ha_mcp_version: "7.9.0"
   claude_auto_update: true
   dangerously_skip_permissions: false
   claude_extra_args: ""
@@ -41,6 +42,7 @@ schema:
   auto_launch_claude: bool?
   ha_smart_context: bool?
   enable_ha_mcp: bool?
+  ha_mcp_version: str?
   claude_auto_update: bool?
   dangerously_skip_permissions: bool?
   claude_extra_args: str?

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Terminal with Anthropic's Claude Code CLI, persistent auth, and packages"
-version: "2.3.1"
+version: "2.3.2"
 slug: "claude_terminal"
 init: false
 

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Terminal with Anthropic's Claude Code CLI, persistent auth, and packages"
-version: "2.2.2"
+version: "2.3.0"
 slug: "claude_terminal"
 init: false
 
@@ -32,12 +32,14 @@ options:
   auto_launch_claude: true
   ha_smart_context: true
   enable_ha_mcp: true
+  claude_auto_update: true
   persistent_apk_packages: []
   persistent_pip_packages: []
 schema:
   auto_launch_claude: bool?
   ha_smart_context: bool?
   enable_ha_mcp: bool?
+  claude_auto_update: bool?
   persistent_apk_packages:
     - str
   persistent_pip_packages:

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Terminal with Anthropic's Claude Code CLI, persistent auth, and packages"
-version: "2.3.0"
+version: "2.3.1"
 slug: "claude_terminal"
 init: false
 
@@ -33,6 +33,8 @@ options:
   ha_smart_context: true
   enable_ha_mcp: true
   claude_auto_update: true
+  dangerously_skip_permissions: false
+  claude_extra_args: ""
   persistent_apk_packages: []
   persistent_pip_packages: []
 schema:
@@ -40,6 +42,8 @@ schema:
   ha_smart_context: bool?
   enable_ha_mcp: bool?
   claude_auto_update: bool?
+  dangerously_skip_permissions: bool?
+  claude_extra_args: str?
   persistent_apk_packages:
     - str
   persistent_pip_packages:

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -35,6 +35,11 @@ init_environment() {
     export ANTHROPIC_CONFIG_DIR="$claude_config_dir"
     export ANTHROPIC_HOME="/data"
 
+    # Prefer a persistent native Claude Code install under /data over the npm
+    # copy baked into the image (frozen at whatever version was current when
+    # the image was built). Propagates through ttyd -> bash -> tmux -> claude.
+    export PATH="${data_home}/.local/bin:${PATH}"
+
     # Migrate any existing authentication files from legacy locations
     migrate_legacy_auth_files "$claude_config_dir"
 
@@ -181,6 +186,69 @@ install_persistent_packages() {
 
     if [ -z "$apk_packages" ] && [ -z "$pip_packages" ]; then
         bashio::log.info "No persistent packages configured"
+    fi
+}
+
+# Install or update a persistent native Claude Code build under /data.
+# The npm copy baked into the image is frozen at image build time and the
+# container filesystem is recreated on every restart, so a native install in
+# /data is the only way to keep Claude Code current across restarts.
+update_claude_native() {
+    local claude_auto_update
+    claude_auto_update=$(bashio::config 'claude_auto_update' 'true')
+
+    if [ "$claude_auto_update" != "true" ]; then
+        bashio::log.info "Claude Code auto-update disabled in configuration"
+        return 0
+    fi
+
+    # Native builds are only published for x86_64/aarch64; other architectures
+    # (armv7) keep the npm copy bundled in the image
+    local machine
+    machine=$(uname -m)
+    case "$machine" in
+        x86_64|aarch64) ;;
+        *)
+            bashio::log.info "No native Claude Code build for ${machine}, using bundled npm version"
+            return 0
+            ;;
+    esac
+
+    if [ -x "${HOME}/.local/bin/claude" ]; then
+        # Native install already present: check for updates in the background
+        # so startup is never delayed
+        bashio::log.info "Native Claude Code found, checking for updates in background..."
+        (timeout 300 "${HOME}/.local/bin/claude" update >/dev/null 2>&1 || true) &
+    else
+        # First run: install the native build (one-time cost). Probe
+        # connectivity first so an offline boot is not delayed.
+        if ! curl -fsSL -m 10 -o /dev/null https://claude.ai/install.sh 2>/dev/null; then
+            bashio::log.warning "Cannot reach claude.ai, using bundled npm Claude Code for now"
+            return 0
+        fi
+        bashio::log.info "Installing native Claude Code build to ${HOME}/.local/bin (persists in /data)..."
+        if timeout 300 bash -c "curl -fsSL https://claude.ai/install.sh | bash" >/dev/null 2>&1; then
+            bashio::log.info "Native Claude Code installed successfully"
+        else
+            bashio::log.warning "Native Claude Code install failed, using bundled npm version"
+        fi
+    fi
+
+    bashio::log.info "Active Claude Code: $(command -v claude || echo 'not found') $(claude --version 2>/dev/null || echo '(version unavailable)')"
+}
+
+# Source user-provided init hooks from /data/init.d (persists across restarts).
+# Escape hatch for customizing the ephemeral container at startup, e.g.
+# exporting environment variables or adjusting PATH before ttyd launches.
+source_user_init_hooks() {
+    if [ -d /data/init.d ]; then
+        local hook
+        for hook in /data/init.d/*.sh; do
+            [ -r "$hook" ] || continue
+            bashio::log.info "Sourcing user init hook: ${hook}"
+            # shellcheck disable=SC1090
+            source "$hook" || bashio::log.warning "Init hook failed: ${hook}"
+        done
     fi
 }
 
@@ -367,6 +435,8 @@ main() {
     install_tools
     setup_session_picker
     install_persistent_packages
+    update_claude_native
+    source_user_init_hooks
     generate_ha_context
     setup_ha_mcp
     start_web_terminal

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -237,6 +237,33 @@ update_claude_native() {
     bashio::log.info "Active Claude Code: $(command -v claude || echo 'not found') $(claude --version 2>/dev/null || echo '(version unavailable)')"
 }
 
+# Assemble extra launch flags for claude, exported as CLAUDE_LAUNCH_ARGS so
+# both the auto-launch command and the session picker apply them consistently.
+setup_claude_launch_args() {
+    local launch_args=""
+
+    # Opt-in bypass of Claude Code's permission prompts. Claude refuses this
+    # flag for the root user unless IS_SANDBOX=1 marks the environment as a
+    # disposable container, which this add-on is.
+    if bashio::config.true 'dangerously_skip_permissions'; then
+        bashio::log.warning "dangerously_skip_permissions is enabled: Claude will not ask before running tools"
+        export IS_SANDBOX=1
+        launch_args="--dangerously-skip-permissions"
+    fi
+
+    local extra_args
+    extra_args=$(bashio::config 'claude_extra_args' '')
+    if [ -n "$extra_args" ] && [ "$extra_args" != "null" ]; then
+        launch_args="${launch_args} ${extra_args}"
+    fi
+
+    CLAUDE_LAUNCH_ARGS=$(echo "$launch_args" | xargs)
+    export CLAUDE_LAUNCH_ARGS
+    if [ -n "$CLAUDE_LAUNCH_ARGS" ]; then
+        bashio::log.info "Claude launch args: ${CLAUDE_LAUNCH_ARGS}"
+    fi
+}
+
 # Source user-provided init hooks from /data/init.d (persists across restarts).
 # Escape hatch for customizing the ephemeral container at startup, e.g.
 # exporting environment variables or adjusting PATH before ttyd launches.
@@ -344,9 +371,15 @@ get_claude_launch_command() {
         welcome_prefix="welcome; "
     fi
 
+    # Apply configured launch flags (see setup_claude_launch_args)
+    local claude_cmd="claude"
+    if [ -n "${CLAUDE_LAUNCH_ARGS:-}" ]; then
+        claude_cmd="claude ${CLAUDE_LAUNCH_ARGS}"
+    fi
+
     if [ "$auto_launch_claude" = "true" ]; then
         # Use tmux for session persistence - attach to existing or create new
-        echo "${welcome_prefix}tmux new-session -A -s claude 'claude'"
+        echo "${welcome_prefix}tmux new-session -A -s claude '${claude_cmd}'"
     else
         # Session picker manages its own tmux sessions internally,
         # so do NOT wrap it in tmux (that would cause nested tmux errors)
@@ -355,7 +388,7 @@ get_claude_launch_command() {
         else
             # Fallback if session picker is missing
             bashio::log.warning "Session picker not found, falling back to auto-launch"
-            echo "${welcome_prefix}tmux new-session -A -s claude 'claude'"
+            echo "${welcome_prefix}tmux new-session -A -s claude '${claude_cmd}'"
         fi
     fi
 }
@@ -436,6 +469,7 @@ main() {
     setup_session_picker
     install_persistent_packages
     update_claude_native
+    setup_claude_launch_args
     source_user_init_hooks
     generate_ha_context
     setup_ha_mcp

--- a/claude-terminal/scripts/claude-session-picker.sh
+++ b/claude-terminal/scripts/claude-session-picker.sh
@@ -89,7 +89,7 @@ launch_claude_new() {
     fi
 
     sleep 1
-    exec tmux new-session -s "$TMUX_SESSION_NAME" 'claude'
+    exec tmux new-session -s "$TMUX_SESSION_NAME" "claude ${CLAUDE_LAUNCH_ARGS:-}"
 }
 
 launch_claude_continue() {
@@ -100,7 +100,7 @@ launch_claude_continue() {
     fi
 
     sleep 1
-    exec tmux new-session -s "$TMUX_SESSION_NAME" 'claude -c'
+    exec tmux new-session -s "$TMUX_SESSION_NAME" "claude -c ${CLAUDE_LAUNCH_ARGS:-}"
 }
 
 launch_claude_resume() {
@@ -111,7 +111,7 @@ launch_claude_resume() {
     fi
 
     sleep 1
-    exec tmux new-session -s "$TMUX_SESSION_NAME" 'claude -r'
+    exec tmux new-session -s "$TMUX_SESSION_NAME" "claude -r ${CLAUDE_LAUNCH_ARGS:-}"
 }
 
 launch_claude_custom() {

--- a/claude-terminal/scripts/health-check.sh
+++ b/claude-terminal/scripts/health-check.sh
@@ -7,8 +7,9 @@ check_system_resources() {
     bashio::log.info "=== System Resources Check ==="
 
     # Check available memory
-    local mem_total=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo)
-    local mem_free=$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo)
+    local mem_total mem_free
+    mem_total=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo)
+    mem_free=$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo)
     bashio::log.info "Memory: ${mem_free}MB free of ${mem_total}MB total"
 
     if [ "$mem_free" -lt 256 ]; then
@@ -17,7 +18,8 @@ check_system_resources() {
     fi
 
     # Check disk space in /data
-    local disk_free=$(df -m /data | tail -1 | awk '{print $4}')
+    local disk_free
+    disk_free=$(df -m /data | tail -1 | awk '{print $4}')
     bashio::log.info "Disk space in /data: ${disk_free}MB free"
 
     if [ "$disk_free" -lt 100 ]; then
@@ -51,7 +53,8 @@ check_node_installation() {
     bashio::log.info "=== Node.js Installation Check ==="
 
     if command -v node >/dev/null 2>&1; then
-        local node_version=$(node --version)
+        local node_version
+        node_version=$(node --version)
         bashio::log.info "Node.js installed: $node_version ✓"
     else
         bashio::log.error "Node.js not found ✗"
@@ -59,7 +62,8 @@ check_node_installation() {
     fi
 
     if command -v npm >/dev/null 2>&1; then
-        local npm_version=$(npm --version)
+        local npm_version
+        npm_version=$(npm --version)
         bashio::log.info "npm installed: $npm_version ✓"
     else
         bashio::log.error "npm not found ✗"

--- a/claude-terminal/scripts/setup-ha-mcp.sh
+++ b/claude-terminal/scripts/setup-ha-mcp.sh
@@ -30,9 +30,37 @@ configure_ha_mcp_server() {
         return 0
     fi
 
+    # Resolve the ha-mcp version to install (configurable via add-on options
+    # so it can be bumped without waiting for an add-on release)
+    local ha_mcp_version
+    ha_mcp_version=$(bashio::config 'ha_mcp_version' '7.9.0')
+    if [ -z "$ha_mcp_version" ] || [ "$ha_mcp_version" = "null" ]; then
+        ha_mcp_version="7.9.0"
+    fi
+
+    # ha-mcp >=3.6 requires CPython 3.13 exactly (requires-python >=3.13,<3.14)
+    # while Alpine ships 3.12, so let uv provision a managed musl Python 3.13.
+    # It lands under XDG_DATA_HOME (/data), so it persists across restarts.
+    # No managed musl builds exist for armv7 - stay on ha-mcp 3.5.1 there,
+    # the last release that runs on the system Python.
+    local machine
+    local uvx_python_args=()
+    machine=$(uname -m)
+    case "$machine" in
+        x86_64|aarch64)
+            uvx_python_args=(--python 3.13)
+            ;;
+        *)
+            if [ "$ha_mcp_version" != "3.5.1" ]; then
+                bashio::log.warning "No managed Python 3.13 builds for ${machine}; using ha-mcp@3.5.1"
+                ha_mcp_version="3.5.1"
+            fi
+            ;;
+    esac
+
     # Configure Claude Code to use ha-mcp
     # The MCP server will connect to Home Assistant via the Supervisor API
-    bashio::log.info "Configuring Claude Code MCP server for Home Assistant..."
+    bashio::log.info "Configuring Claude Code MCP server for Home Assistant (ha-mcp@${ha_mcp_version})..."
 
     # Remove existing ha-mcp configuration if present (to ensure clean state)
     claude mcp remove home-assistant 2>/dev/null || true
@@ -45,13 +73,19 @@ configure_ha_mcp_server() {
     if claude mcp add home-assistant \
         --env "HOMEASSISTANT_URL=http://supervisor/core" \
         --env "HOMEASSISTANT_TOKEN=${SUPERVISOR_TOKEN}" \
-        -- uvx --index-strategy unsafe-best-match ha-mcp@3.5.1; then
+        -- uvx "${uvx_python_args[@]}" --index-strategy unsafe-best-match "ha-mcp@${ha_mcp_version}"; then
         bashio::log.info "ha-mcp configured successfully!"
         bashio::log.info "Claude Code now has access to Home Assistant via MCP"
         bashio::log.info "Available tools: entity control, automations, scripts, history, and more"
+
+        # Pre-warm the uv caches in the background: the first launch downloads
+        # Python 3.13 and the ha-mcp package into /data, which could otherwise
+        # exceed the MCP client startup timeout on first connection
+        (timeout 600 uvx "${uvx_python_args[@]}" --index-strategy unsafe-best-match \
+            "ha-mcp@${ha_mcp_version}" --help </dev/null >/dev/null 2>&1 || true) &
     else
         bashio::log.warning "Failed to configure ha-mcp - continuing without MCP integration"
-        bashio::log.warning "You can manually run: claude mcp add home-assistant --env HOMEASSISTANT_URL=http://supervisor/core --env HOMEASSISTANT_TOKEN=\$SUPERVISOR_TOKEN -- uvx --index-strategy unsafe-best-match ha-mcp@3.5.1"
+        bashio::log.warning "You can manually run: claude mcp add home-assistant --env HOMEASSISTANT_URL=http://supervisor/core --env HOMEASSISTANT_TOKEN=\$SUPERVISOR_TOKEN -- uvx ${uvx_python_args[*]} --index-strategy unsafe-best-match ha-mcp@${ha_mcp_version}"
     fi
 }
 

--- a/claude-terminal/scripts/welcome.sh
+++ b/claude-terminal/scripts/welcome.sh
@@ -34,7 +34,7 @@ save_version() {
 show_welcome_banner() {
     local version="$1"
     local ver_padding
-    ver_padding=$(printf '%*s' $((34 - ${#version})) '')
+    ver_padding=$(printf '%*s' $((37 - ${#version})) '')
     echo ""
     echo -e "  ${TERRACOTTA}╔══════════════════════════════════════════════════════════╗${NC}"
     echo -e "  ${TERRACOTTA}║${NC}                                                          ${TERRACOTTA}║${NC}"

--- a/claude-terminal/scripts/welcome.sh
+++ b/claude-terminal/scripts/welcome.sh
@@ -5,9 +5,7 @@
 # Uses plain bash — no bashio dependency
 
 # Colors
-CYAN='\033[0;36m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 TERRACOTTA='\033[38;2;217;119;87m'
 WHITE='\033[1;37m'
 BOLD='\033[1m'
@@ -44,6 +42,20 @@ show_welcome_banner() {
     echo -e "  ${TERRACOTTA}║${NC}   ${DIM}Home Assistant Add-on  ·  Powered by Claude Code CLI${NC}   ${TERRACOTTA}║${NC}"
     echo -e "  ${TERRACOTTA}║${NC}                                                          ${TERRACOTTA}║${NC}"
     echo -e "  ${TERRACOTTA}╚══════════════════════════════════════════════════════════╝${NC}"
+}
+
+# Show which Claude Code binary this terminal will run (the add-on keeps a
+# self-updating native install in /data; /usr/local|/usr is the bundled copy)
+show_claude_version() {
+    local claude_path claude_ver source_label
+    claude_path=$(command -v claude 2>/dev/null || echo "not installed")
+    claude_ver=$(claude --version 2>/dev/null | awk '{print $1; exit}')
+    case "$claude_path" in
+        /data/*) source_label="native install, auto-updating" ;;
+        *)       source_label="bundled with add-on image" ;;
+    esac
+    echo -e "  ${DIM}Claude Code ${claude_ver:-unknown}  ·  ${claude_path}${NC}"
+    echo -e "  ${DIM}(${source_label})${NC}"
 }
 
 show_whats_new() {
@@ -85,6 +97,7 @@ main() {
     last_seen=$(get_last_seen_version)
 
     show_welcome_banner "$current_version"
+    show_claude_version
     show_whats_new "$current_version" "$last_seen"
 
     echo ""


### PR DESCRIPTION
## Problem

The Dockerfile installs `@anthropic-ai/claude-code@latest`, but because this add-on is built locally by the Supervisor, `@latest` is resolved once at install/update time and then frozen into the image. Since the container filesystem is recreated on every restart, any in-place update a user performs is thrown away. Users end up pinned to whatever version was current when they installed the add-on (e.g. 2.1.114 while npm is at 2.1.201 — Claude Code ships several releases a week), with no way to update short of the add-on itself releasing a new version.

## Solution

**`claude_auto_update` option (default: `true`)** — on first startup, install the official native Claude Code build into `/data` (which persists across restarts and add-on updates); on subsequent startups, run `claude update` in the background so boot is never delayed. `$HOME/.local/bin` (= `/data/home/.local/bin`) is prepended to `PATH`, so the persistent native install wins everywhere — auto-launch, session picker, auth helper, and MCP setup all invoke bare `claude`, and the environment propagates through ttyd → bash → tmux.

**`/data/init.d/*.sh` startup hooks** — sourced before the terminal launches; a persistent escape hatch for customizing the ephemeral container (env vars, PATH, tool setup), following the same philosophy as `persistent_apk_packages`.

**`dangerously_skip_permissions` option (default: `false`)** — launches Claude with `--dangerously-skip-permissions`. Claude Code refuses this flag for root unless `IS_SANDBOX=1` marks the environment as a disposable container, so the option exports it. Startup logs a warning; DOCS carry a security note.

**`claude_extra_args` option** — extra flags appended to every Claude launch (auto-launch and the session picker's standard modes).

**Welcome banner now shows the active Claude Code version and path** — users in auto-launch mode have no shell, so the banner and the add-on log (`Active Claude Code: …`) are their way to verify what's running.

## ha-mcp: 3.5.1 → 7.9.0 (fixes WebSocket tools) + `ha_mcp_version` option

ha-mcp 3.5.1 is four major versions behind, and its WebSocket-based tools (e.g. `ha_eval_template`) fail with "WebSocket not connected" even though the Supervisor proxy WebSocket path is healthy (verified with a raw WS handshake from inside the container). The pin was stuck for a structural reason: **every ha-mcp release after 3.5.1 requires CPython 3.13 exactly** (`>=3.13,<3.14`), which no Alpine release ships (3.21–3.23 have 3.12, 3.24 has 3.14), and Alpine's apk-packaged uv (0.5.31) is too old to download managed musl Python builds. This PR:

- Installs uv 0.11.26 from the official installer instead of apk — recent uv can provision managed musl CPython builds
- Launches ha-mcp with `uvx --python 3.13`; the managed interpreter lands under `XDG_DATA_HOME` (`/data`) and persists across restarts
- Pre-warms the uv caches in the background after `claude mcp add`, so the first MCP connection doesn't hit the client startup timeout
- Adds an `ha_mcp_version` option (default `"7.9.0"`) so future bumps are a config change, not a release
- armv7 (no managed musl Python builds) stays on ha-mcp 3.5.1

ha-mcp 7.9.0 was probed via MCP `tools/list`: 77 tools, including `ha_eval_template`, `ha_get_state`, `ha_get_entity`, `ha_search`, `ha_call_service`, and the automation/scene/script config tools.

## On the musl history (v1.6.0 → v1.9.0 revert)

The v1.9.0 revert cited the native binary requiring musl 1.2.6+ (`posix_getdents`), which Alpine 3.21 doesn't ship. Current native builds (2.1.x) run fine on the Alpine 3.21 base — verified on an amd64 HAOS VM and an aarch64 container. This PR also keeps three fallbacks: armv7 (no native builds) always uses the bundled npm copy, offline first boots skip the install (with a connectivity probe so startup isn't delayed), and any install failure falls back to the bundled copy. Worth knowing: the native installer removes the npm copy from the container overlay when it runs — harmless, since the overlay is recreated from the image on every restart.

## Also included

- Fixed pre-existing shellcheck warnings (SC2034 in `welcome.sh`, SC2155 in `health-check.sh`) that fail the ShellCheck workflow for any PR touching `claude-terminal/`
- Fixed the welcome banner border misalignment on the version line (padding was 3 columns short)

## Testing

- shellcheck and hadolint pass with the repo's CI flags on all touched files
- Container tests against a mocked Supervisor API: first boot installs native Claude Code into `/data` (~17 s); a recreated container (same `/data`, fresh overlay — exact restart semantics) picks it up instantly with a background update check; PATH, `IS_SANDBOX`, and `CLAUDE_LAUNCH_ARGS` propagate into ttyd; init hooks source correctly; the MCP server registers as `uvx --python 3.13 --index-strategy unsafe-best-match ha-mcp@7.9.0` and a cache-warmed launch initializes in seconds
- Deployed on a real HAOS instance as a custom repository: native install, OAuth, restarts, skip-permissions flow, and ha-mcp 7.9.0 template rendering (`ha_eval_template`) all verified working

## CI notes

- The `claude-review` job fails because fork PRs don't receive `CLAUDE_CODE_OAUTH_TOKEN`; nothing I can do from the fork side
- The aarch64 build job appears flaky under QEMU: the identical `npm install -g @anthropic-ai/claude-code@latest` layer passed on this PR's first run and crashed with SIGILL on the second

Version is set to 2.3.3 with changelog entries — happy to renumber/squash however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)