### PR TITLE
v2.3.1 — fix clipboard copy (OAuth login URL) under tmux mouse mode

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.3.1
+
+### 🐛 Bug Fixes
+- **Fixed copying (including the OAuth login URL) not reaching the clipboard**:
+  ttyd's `xterm-256color` terminfo lacks the `Ms` capability, so tmux never
+  actually emitted OSC 52 — mouse-drag copies landed in tmux's internal buffer
+  only, which broke the first-login flow introduced alongside 2.3.0's mouse
+  mode. tmux is now told the OSC 52 escape sequence explicitly; drag-copy and
+  Claude's login "press `c` to copy" both reach the browser clipboard (HTTPS
+  required by browsers), and wrapped URLs are copied as a single joined line
+- Documented Shift+drag (native browser selection, bypasses tmux) as the
+  fallback for plain-`http://` access, plus a login troubleshooting section
+
 ## 2.3.0
 
 Back to basics: the add-on's job is Claude Code in a terminal, done reliably.

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -47,7 +47,8 @@ ha-context      # refresh the Home Assistant context file
 ### Terminal tips
 
 - **Scrolling**: use the mouse wheel — tmux copy-mode opens automatically. Press `q` to jump back to the bottom.
-- **Copying**: select text with the mouse; it's copied to your clipboard automatically (OSC 52).
+- **Copying**: select text with the mouse; on release it's copied to your clipboard (OSC 52). Long wrapped lines (like OAuth URLs) are joined back into one line automatically. Note: browsers only allow clipboard writes on secure pages — if you access Home Assistant over plain `http://`, use Shift+drag instead.
+- **Shift+drag**: bypasses tmux and gives you the browser's native text selection (copy with `Ctrl+C` / right-click). Works everywhere, but wrapped lines are copied with line breaks — rejoin them by hand.
 - **Pasting**: use `Ctrl+Shift+V` (or right-click, depending on browser).
 
 ### File access
@@ -71,6 +72,7 @@ Disable it with `enable_ha_mcp: false` if you don't want Claude to have this acc
 
 ## Troubleshooting
 
+- **Can't copy the OAuth login URL**: at Claude's login prompt, press `c` to copy the URL to your clipboard (requires accessing HA over HTTPS). Alternatively, drag over the URL with the mouse — tmux copies it as a single joined line on release. On plain `http://`, use Shift+drag and rejoin the wrapped line after pasting. Don't click the link directly: the browser's link detection truncates URLs that wrap across lines.
 - **Claude exits immediately or behaves oddly**: restart the add-on so the background auto-updater can fetch the latest Claude Code; check the add-on log for update messages.
 - **Diagnostics**: run `claude-doctor` in the terminal for connectivity, memory, and environment checks.
 - **Authentication problems**: run `claude /logout` inside Claude, then log in again.

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Web terminal with Anthropic's Claude Code CLI and persistent auth"
-version: "2.3.0"
+version: "2.3.1"
 slug: "claude_terminal"
 init: false
 

--- a/claude-terminal/scripts/tmux.conf
+++ b/claude-terminal/scripts/tmux.conf
@@ -39,9 +39,16 @@ set -g update-environment "SUPERVISOR_TOKEN ANTHROPIC_CONFIG_DIR XDG_CONFIG_HOME
 # alternate screen (issues #55, #82).
 set -g mouse on
 
-# OSC 52 clipboard support - sends copied text to browser clipboard                                                                                                                                                                                                                                                                                                                                                                                     
+# OSC 52 clipboard support - sends copied text to browser clipboard
 set -g set-clipboard on
 set -g allow-passthrough on
+
+# ttyd advertises TERM=xterm-256color, whose terminfo lacks the Ms capability,
+# so tmux would never actually emit OSC 52 (copies silently stayed in tmux's
+# internal buffer — broke copying the OAuth login URL). Teach tmux the escape
+# sequence explicitly so drag-copy and app-side copies (e.g. Claude's login
+# "press c to copy") reach the browser clipboard.
+set -ga terminal-overrides ',*:Ms=\E]52;%p1%s;%p2%s\007'
 
 # Increase scroll-back buffer significantly (default is 2000)
 set -g history-limit 50000


### PR DESCRIPTION
## Problem (regression found while testing 2.3.0)

With 2.3.0's tmux mouse mode, drag selection is captured by tmux instead of the browser, and the intended clipboard path — tmux emitting OSC 52 — never actually fired: ttyd advertises `TERM=xterm-256color`, whose terminfo lacks the `Ms` capability, so tmux silently kept copies in its internal buffer. Combined with xterm.js truncating hyperlinks at line wraps, there was no working way to copy the OAuth login URL out of the terminal.

## Fix

- `tmux.conf`: explicit `Ms` entry in `terminal-overrides` so tmux emits OSC 52. This makes both mouse drag-copy and application-side copies (Claude's login "press `c` to copy") reach the browser clipboard. Bonus over pre-2.3.0 behavior: tmux joins soft-wrapped lines, so a wrapped OAuth URL is copied as one intact line.
- DOCS: terminal tips now cover Shift+drag (native browser selection, bypasses tmux — the universal fallback, required on plain `http://` where browsers block clipboard writes), and a new troubleshooting entry for the login-URL flow.
- Version 2.3.1 + changelog.

## Notes

- Diff is tmux.conf + docs + version bump only; no boot-path or Dockerfile changes.
- OSC 52 clipboard writes require a secure context (HTTPS) — that's a browser restriction; Shift+drag is documented for HTTP users.

## Testing

- tmux config parses cleanly (`tmux -f ... start-server`)
- Clipboard behavior needs verification in the real ingress terminal: drag-copy a wrapped URL and paste it; press `c` at Claude's login prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak)_