### PR TITLE
v2.3.2 — claude-login-url helper: reliable OAuth login despite clipboard truncation

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.3.2
+
+### 🐛 Bug Fixes
+- **New `claude-login-url` command**: saves the OAuth login URL to
+  `/config/claude-login-url.txt` so it can be copied via the File Editor or
+  Samba. The browser terminal's OSC 52 clipboard path truncates payloads at
+  roughly 400 characters — shorter than the login URL — which cut off the
+  `state` parameter and made authorization fail with "Invalid request format".
+  This gives login a path that bypasses the terminal clipboard entirely.
+- **Auth status indicator now checks token expiry**: a leftover credentials
+  file with an expired token shows orange instead of green
+
 ## 2.3.1
 
 ### 🐛 Bug Fixes

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -40,6 +40,7 @@ claude          # start Claude Code
 claude -c       # continue the most recent conversation
 claude -r       # pick a past conversation to resume
 claude-doctor   # diagnose network, auth, and environment issues
+claude-login-url   # save the OAuth login URL to /config (see Troubleshooting)
 persist-install apk htop   # install packages that survive restarts
 ha-context      # refresh the Home Assistant context file
 ```
@@ -72,7 +73,7 @@ Disable it with `enable_ha_mcp: false` if you don't want Claude to have this acc
 
 ## Troubleshooting
 
-- **Can't copy the OAuth login URL**: at Claude's login prompt, press `c` to copy the URL to your clipboard (requires accessing HA over HTTPS). Alternatively, drag over the URL with the mouse — tmux copies it as a single joined line on release. On plain `http://`, use Shift+drag and rejoin the wrapped line after pasting. Don't click the link directly: the browser's link detection truncates URLs that wrap across lines.
+- **Can't copy the OAuth login URL / "Authorization failed – Invalid request format"**: the browser terminal's clipboard path truncates very long payloads, and the login URL is one — a cut-off `state` parameter causes exactly that authorization error. Reliable path: while the login prompt is showing, open a second tmux window (`Ctrl+B` then `C`), run `claude-login-url`, and open `/config/claude-login-url.txt` with the File Editor add-on (or over Samba) — copy the URL from there. Switch back with `Ctrl+B` then `L` to paste the resulting code. Delete the file when done. Don't click the link in the terminal directly: link detection truncates URLs that wrap across lines.
 - **Claude exits immediately or behaves oddly**: restart the add-on so the background auto-updater can fetch the latest Claude Code; check the add-on log for update messages.
 - **Diagnostics**: run `claude-doctor` in the terminal for connectivity, memory, and environment checks.
 - **Authentication problems**: run `claude /logout` inside Claude, then log in again.

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Web terminal with Anthropic's Claude Code CLI and persistent auth"
-version: "2.3.1"
+version: "2.3.2"
 slug: "claude_terminal"
 init: false
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -109,7 +109,8 @@ setup_commands() {
         "welcome:/opt/scripts/welcome.sh" \
         "persist-install:/opt/scripts/persist-install.sh" \
         "ha-context:/opt/scripts/ha-context.sh" \
-        "claude-doctor:/opt/scripts/health-check.sh"; do
+        "claude-doctor:/opt/scripts/health-check.sh" \
+        "claude-login-url:/opt/scripts/claude-login-url.sh"; do
         name="${entry%%:*}"
         script="${entry#*:}"
         if [ -f "$script" ]; then

--- a/claude-terminal/scripts/claude-login-url.sh
+++ b/claude-terminal/scripts/claude-login-url.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# claude-login-url — extract the most recent OAuth login URL from the Claude
+# tmux session and save it to /config, where it can be opened via the Home
+# Assistant File Editor or Samba and copied without going through the
+# terminal clipboard at all.
+#
+# Why: the browser terminal's OSC 52 clipboard path truncates long payloads
+# (~400 chars), and Claude Code's login URL is ~450+ chars — the tail (the
+# `state` parameter) gets cut off, which makes authorization fail with
+# "Invalid request format". capture-pane with -J joins soft-wrapped lines,
+# so the URL comes out intact regardless of terminal width.
+
+OUT="${1:-/config/claude-login-url.txt}"
+
+url=$(tmux capture-pane -p -J -t claude -S -500 2>/dev/null \
+    | grep -oE "https://(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)[^[:space:]\"'\`)<>]*" \
+    | tail -1)
+
+if [ -z "$url" ]; then
+    echo "No login URL found in the Claude session." >&2
+    echo "Start the login in Claude first (run /login), then run this command again." >&2
+    exit 1
+fi
+
+printf '%s\n' "$url" > "$OUT"
+chmod 600 "$OUT"
+
+echo "Login URL saved to: $OUT"
+echo "Open it with the Home Assistant File Editor (or over Samba), copy the"
+echo "whole line into your browser, and authorize. Delete the file afterwards."

--- a/claude-terminal/scripts/tmux-status.sh
+++ b/claude-terminal/scripts/tmux-status.sh
@@ -8,11 +8,23 @@ auth_status() {
     local config_dir="${ANTHROPIC_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}"
 
     # Current Claude Code stores OAuth credentials in ~/.claude; older
-    # versions used the config dir
-    if [ -f "$HOME/.claude/.credentials.json" ] || \
-       [ -f "$config_dir/.credentials.json" ] || [ -f "$config_dir/credentials.json" ]; then
-        echo "#[fg=colour114]Auth"
-    elif [ -f "$config_dir/settings.json" ] && \
+    # versions used the config dir. A file with an expired token shows
+    # orange, not green — existence alone doesn't mean logged in.
+    local cred
+    for cred in "$HOME/.claude/.credentials.json" \
+                "$config_dir/.credentials.json" "$config_dir/credentials.json"; do
+        [ -f "$cred" ] || continue
+        local expires_at
+        expires_at=$(jq -r '.claudeAiOauth.expiresAt // empty' "$cred" 2>/dev/null)
+        if [ -n "$expires_at" ] && [ "$expires_at" -lt "$(( $(date +%s) * 1000 ))" ] 2>/dev/null; then
+            echo "#[fg=colour208]Auth"
+        else
+            echo "#[fg=colour114]Auth"
+        fi
+        return
+    done
+
+    if [ -f "$config_dir/settings.json" ] && \
        grep -q '"apiKey"\|"oauthToken"\|"sessionKey"' "$config_dir/settings.json" 2>/dev/null; then
         echo "#[fg=colour114]Auth"
     else


### PR DESCRIPTION
## Problem

Login still failed after 2.3.1: the clipboard now *works*, but the browser-side OSC 52 handler in ttyd/xterm.js truncates payloads at ~400 characters. The OAuth login URL is ~450+ characters, so the trailing `state` parameter was cut off → Anthropic's consent page renders, but clicking Authorize returns **"Authorization failed – Invalid request format"**.

Verified empirically: an 800-character payload passes through tmux's OSC 52 emission intact (tested with `set-buffer -w` under a captured pty), so the cap is downstream in ttyd's frontend, which we can't configure.

## Fix

- **New `claude-login-url` command**: extracts the most recent login URL from the `claude` tmux pane (`capture-pane -J` joins soft-wrapped lines, so the URL is intact at any terminal width) and writes it to `/config/claude-login-url.txt` (mode 600). The user opens that file with the File Editor add-on or over Samba and copies from there — no terminal clipboard involved, so nothing can truncate.
- **Auth status indicator now validates token expiry** (`claudeAiOauth.expiresAt`): a leftover credentials file with a dead token shows orange instead of a misleading green "Auth".
- DOCS troubleshooting rewritten around the reliable path; version 2.3.2 + changelog.

## Testing

- shellcheck passes (CI flags) on all scripts
- Functional test against a live tmux pane: URL with full `state` parameter extracted intact; hardened the match against trailing quote/bracket junk
- Expiry check: verified `jq` expression against the real credentials file format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak)_