### PR TITLE
v2.4.0 — ha-mcp 3.5.1 → 7.11.0 (uv-managed Python 3.13) + GHCR publish workflow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,46 @@
+name: Publish Images
+
+# Builds the add-on for all architectures and pushes the images to GHCR.
+# Once the packages are made public and config.yaml gains an `image:` key,
+# Home Assistant installs pull these prebuilt images instead of building
+# locally — which fixes build OOM on small boxes (#56) and stops the
+# Supervisor from exporting the locally-built image into every backup
+# (the second half of #103).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "claude-terminal/**"
+
+jobs:
+  publish:
+    name: Publish (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [aarch64, amd64, armv7]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push add-on image
+        uses: home-assistant/builder@2026.06.0
+        with:
+          args: |
+            --${{ matrix.arch }} \
+            --target /data/claude-terminal \
+            --image "${{ matrix.arch }}-addon-claude-terminal" \
+            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
+            --addon

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 2.4.0
+
+### ✨ ha-mcp 3.5.1 → 7.11.0 (four major versions)
+The bundled Home Assistant MCP server was pinned to 3.5.1 for a structural
+reason: every later release requires CPython 3.13 exactly, which no Alpine
+release ships, and Alpine's packaged uv was too old to install managed musl
+Python builds. Approach adapted from #104 by [@WKassebaum](https://github.com/WKassebaum):
+
+- uv is now installed from PyPI (pinned 0.11.28) and provisions a managed
+  musl CPython 3.13 under `/data` (downloads once, persists)
+- ha-mcp launches via `uvx --python 3.13`; the environment is pre-warmed in
+  the background so the first MCP connection doesn't hit the startup timeout
+- **Fixes the "WebSocket not connected" tool failures** (#95) — ha-mcp 7.x
+  reworked its WebSocket layer
+- **Fixes the numpy x86_v2 crash on older CPUs** (#76) — ha-mcp 7.x dropped
+  the numpy/textdistance dependency entirely
+- New `ha_mcp_version` option (default `"7.11.0"`) so future bumps are a
+  config change, not a release
+- 32-bit ARM (armv7) stays on ha-mcp 3.5.1 (no managed musl Python builds)
+
+Note: the managed Python and MCP environment add roughly 150–250 MB under
+`/data`, which is included in HA backups. This is a one-time cost, not
+unbounded growth like the old npm cache.
+
+### 🛠️ CI/CD
+- New Publish Images workflow: builds and pushes per-arch images to GHCR on
+  every release. Groundwork for prebuilt installs (no more local builds,
+  build OOM (#56), or image blobs in backups) — activated in a follow-up
+  release once the packages are public.
+
 ## 2.3.2
 
 ### 🐛 Bug Fixes

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -26,6 +26,7 @@ Your credentials are stored under `/data` and persist across restarts and add-on
 | `claude_extra_args` | `""` | Extra flags appended to every Claude launch, e.g. `--model claude-sonnet-5`. Values are split on spaces; quoted multi-word arguments are not supported. |
 | `ha_smart_context` | `true` | Generate a CLAUDE.md with your HA system info so Claude knows your setup. |
 | `enable_ha_mcp` | `true` | Register the [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) MCP server so Claude can control Home Assistant directly. |
+| `ha_mcp_version` | `"7.11.0"` | ha-mcp release to run. 32-bit ARM ignores this and stays on 3.5.1 (no Python 3.13 builds for that platform). |
 | `persistent_apk_packages` | `[]` | APK packages reinstalled on every startup. |
 | `persistent_pip_packages` | `[]` | Python packages reinstalled on every startup. |
 
@@ -62,6 +63,8 @@ The terminal starts in `/config` (your Home Assistant configuration). Also mount
 ## Home Assistant MCP Integration
 
 The bundled [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) server connects Claude to Home Assistant through the Supervisor API — no token setup needed. Claude can query states, control devices, and manage automations, scripts, and dashboards in natural language.
+
+ha-mcp requires Python 3.13, which Alpine doesn't ship — the add-on provisions a managed Python build via [uv](https://github.com/astral-sh/uv) into `/data` on first use (a one-time ~150–250 MB download that persists across restarts and is included in HA backups). The environment is pre-warmed in the background at startup so the first MCP connection is fast.
 
 Disable it with `enable_ha_mcp: false` if you don't want Claude to have this access.
 

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -20,10 +20,14 @@ RUN apk add --no-cache \
     tmux \
     tree \
     ttyd \
-    uv \
     vim \
     wget \
     yq
+
+# uv from PyPI, pinned: Alpine 3.21's apk uv (0.5.x) cannot install managed
+# musl CPython builds, which ha-mcp >= 4.x needs (it requires Python 3.13;
+# Alpine 3.21 ships 3.12). musllinux wheels exist for all three arches.
+RUN pip3 install --no-cache-dir --break-system-packages uv==0.11.28
 
 # Keep the npm cache out of persistent storage so it never lands in HA backups
 ENV npm_config_cache=/tmp/npm-cache

--- a/claude-terminal/README.md
+++ b/claude-terminal/README.md
@@ -47,6 +47,7 @@ Works out of the box. All options:
 | `claude_extra_args` | `""` | Extra flags for every Claude launch |
 | `ha_smart_context` | `true` | Generate HA context file for Claude |
 | `enable_ha_mcp` | `true` | Home Assistant MCP server integration |
+| `ha_mcp_version` | `"7.11.0"` | ha-mcp release to run (armv7 stays on 3.5.1) |
 | `persistent_apk_packages` | `[]` | APK packages to install on startup |
 | `persistent_pip_packages` | `[]` | pip packages to install on startup |
 

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Web terminal with Anthropic's Claude Code CLI and persistent auth"
-version: "2.3.2"
+version: "2.4.0"
 slug: "claude_terminal"
 init: false
 
@@ -35,6 +35,7 @@ options:
   claude_extra_args: ""
   ha_smart_context: true
   enable_ha_mcp: true
+  ha_mcp_version: "7.11.0"
   persistent_apk_packages: []
   persistent_pip_packages: []
 schema:
@@ -44,6 +45,7 @@ schema:
   claude_extra_args: str?
   ha_smart_context: bool?
   enable_ha_mcp: bool?
+  ha_mcp_version: str?
   persistent_apk_packages:
     - str
   persistent_pip_packages:

--- a/claude-terminal/scripts/setup-ha-mcp.sh
+++ b/claude-terminal/scripts/setup-ha-mcp.sh
@@ -20,7 +20,6 @@ configure_ha_mcp_server() {
     # Check for supervisor token (required for HA API access)
     if [ -z "${SUPERVISOR_TOKEN:-}" ]; then
         bashio::log.warning "SUPERVISOR_TOKEN not available - ha-mcp setup skipped"
-        bashio::log.warning "MCP server requires Supervisor API access"
         return 0
     fi
 
@@ -30,28 +29,45 @@ configure_ha_mcp_server() {
         return 0
     fi
 
-    # Configure Claude Code to use ha-mcp
-    # The MCP server will connect to Home Assistant via the Supervisor API
-    bashio::log.info "Configuring Claude Code MCP server for Home Assistant..."
+    local version
+    version=$(bashio::config 'ha_mcp_version' '7.11.0')
+
+    # ha-mcp >= 4.x requires CPython 3.13 exactly, which no Alpine release
+    # ships. uv provisions a managed musl 3.13 build instead (persisted under
+    # /data via XDG_DATA_HOME, so it downloads once). 32-bit ARM has no
+    # managed musl builds — stay on the last release that runs on the system
+    # Python 3.12 there.
+    local python_args=()
+    case "$(uname -m)" in
+        armv7l|armv6l|armhf)
+            version="3.5.1"
+            bashio::log.info "32-bit ARM detected - using ha-mcp ${version} on system Python"
+            ;;
+        *)
+            python_args=(--python 3.13)
+            ;;
+    esac
 
     # Remove existing ha-mcp configuration if present (to ensure clean state)
     claude mcp remove home-assistant 2>/dev/null || true
 
-    # Add ha-mcp as MCP server
-    # Using stdio transport with uvx to run ha-mcp
-    # Environment variables:
-    #   HOMEASSISTANT_URL: Internal Supervisor API endpoint
-    #   HOMEASSISTANT_TOKEN: Supervisor token for authentication
+    # --index-strategy unsafe-best-match: the HA wheels index doesn't carry
+    # every version, so let uv consider all indexes (#77/#79)
     if claude mcp add home-assistant \
         --env "HOMEASSISTANT_URL=http://supervisor/core" \
         --env "HOMEASSISTANT_TOKEN=${SUPERVISOR_TOKEN}" \
-        -- uvx --index-strategy unsafe-best-match ha-mcp@3.5.1; then
-        bashio::log.info "ha-mcp configured successfully!"
-        bashio::log.info "Claude Code now has access to Home Assistant via MCP"
-        bashio::log.info "Available tools: entity control, automations, scripts, history, and more"
+        -- uvx "${python_args[@]}" --index-strategy unsafe-best-match "ha-mcp@${version}"; then
+        bashio::log.info "ha-mcp ${version} configured for Claude Code"
+
+        # Pre-warm the uv environment in the background (managed Python
+        # download + dependency resolution) so the first MCP connection
+        # doesn't hit the client startup timeout
+        (uvx "${python_args[@]}" --index-strategy unsafe-best-match \
+            --from "ha-mcp@${version}" python -c "" >/dev/null 2>&1 || true) &
+        bashio::log.info "Pre-warming ha-mcp environment in background"
     else
         bashio::log.warning "Failed to configure ha-mcp - continuing without MCP integration"
-        bashio::log.warning "You can manually run: claude mcp add home-assistant --env HOMEASSISTANT_URL=http://supervisor/core --env HOMEASSISTANT_TOKEN=\$SUPERVISOR_TOKEN -- uvx --index-strategy unsafe-best-match ha-mcp@3.5.1"
+        bashio::log.warning "You can manually run: claude mcp add home-assistant --env HOMEASSISTANT_URL=http://supervisor/core --env HOMEASSISTANT_TOKEN=\$SUPERVISOR_TOKEN -- uvx --python 3.13 --index-strategy unsafe-best-match ha-mcp@${version}"
     fi
 }
 


### PR DESCRIPTION
The two parked follow-ups from the v2.3.0 cycle, packaged together.

## 1. ha-mcp: 3.5.1 → 7.11.0 (four major versions)

**Why it was stuck** (diagnosis credit: #104 by @WKassebaum): every ha-mcp release after 3.5.1 requires CPython 3.13 exactly (`>=3.13,<3.15` — verified against PyPI metadata today), no Alpine release ships 3.13, and Alpine's apk uv (0.5.x) is too old to download managed musl Python builds.

**What this does:**
- Installs uv from PyPI, pinned to 0.11.28 (musllinux wheels exist for amd64/aarch64/armv7 — verified)
- Registers the MCP server as `uvx --python 3.13 --index-strategy unsafe-best-match ha-mcp@<version>`; the managed interpreter lands under `/data` (via `XDG_DATA_HOME`) and persists
- Pre-warms the uv environment in the background after `claude mcp add`, so the first MCP connection doesn't hit the client startup timeout
- New `ha_mcp_version` option (default `"7.11.0"`) — future bumps are a config change, not a release
- armv7 stays on ha-mcp 3.5.1 on the system Python (no managed musl builds for 32-bit ARM)

**Issues this resolves:**
- Fixes #95 — the "WebSocket connection isn't authenticated" tool failures (ha-mcp 7.x reworked its WebSocket layer; #104 probed 7.9.0's `tools/list` live: 77 tools including `ha_eval_template`)
- Fixes #76 — the numpy x86_v2 SIGILL crash on older CPUs: ha-mcp 7.x **dropped the numpy/textdistance dependency entirely** (verified in 7.11.0's dependency tree: fastmcp, httpx, pydantic, websockets, cryptography — no numpy)

**Verified here:** `uvx --python 3.13 --index-strategy unsafe-best-match --from ha-mcp@7.11.0 python -c "import ha_mcp"` resolves 73 packages and imports cleanly under a uv-managed CPython 3.13. (This container is glibc; the musl path is exactly what #104 validated on real HAOS at 7.9.0.)

**Cost:** managed Python + MCP env ≈ 150–250 MB one-time under `/data` (included in backups; documented in DOCS and changelog).

## 2. GHCR publish workflow (groundwork, no runtime change)

`.github/workflows/publish-images.yml` builds all three arches with `home-assistant/builder@2026.06.0` and pushes `ghcr.io/heytcass/{arch}-addon-claude-terminal` on merges touching `claude-terminal/`.

This is **phase one of two** — config.yaml still builds locally. Rollout plan:
1. Merge this PR → workflow publishes images tagged 2.4.0
2. **Owner action**: make the three GHCR packages public (Profile → Packages → package → settings → visibility)
3. Follow-up one-line release adds `image: "ghcr.io/heytcass/{arch}-addon-claude-terminal"` to config.yaml — from then on installs pull instead of building, which fixes build OOM on 4 GB boxes (#56) and stops the Supervisor exporting the image into every backup (the second half of #103)

Doing the flip in the same release as first publication would risk bricking installs if the packages default to private — hence two phases.

## Testing

- shellcheck (CI flags) passes on all scripts; YAML validated
- PyPI metadata checks: ha-mcp 7.11.0 requirements + uv 0.11.28 wheel coverage per-arch
- Live resolution/import test of the exact production uvx invocation
- Not tested here: musl-specific wheel resolution on a real HAOS box (validated at 7.9.0 by #104); the publish workflow's first run happens on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak)_