### PR TITLE
ci: pin home-assistant/builder to 2026.02.1 (2026.06.0 has no published image)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push add-on image
-        uses: home-assistant/builder@2026.06.0
+        uses: home-assistant/builder@2026.02.1
         with:
           args: |
             --${{ matrix.arch }} \


### PR DESCRIPTION
The first Publish Images run failed in all three jobs: the `2026.06.0` git tag of home-assistant/builder exists, but its builder Docker image was never published — `docker pull ghcr.io/home-assistant/amd64-builder:2026.06.0` fails with "manifest unknown". The action's own master-branch fallback identifies **2026.02.1** as the latest official release *with* a builder image, so pin that.

Workflow-only change; no add-on version bump. Because this commit doesn't touch `claude-terminal/`, the publish workflow won't auto-trigger on merge — I'll fire it via `workflow_dispatch` after merging to verify the images actually build and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak)_