### PR TITLE
ci: drop armv7 from publish matrix (unsupported by current HA builder)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -24,7 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [aarch64, amd64, armv7]
+        # armv7 is not supported by current HA builder releases (32-bit ARM
+        # was dropped upstream); armv7 installs keep building locally
+        arch: [aarch64, amd64]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Second publish run results: **amd64 and aarch64 succeeded** — `2.4.0` images are now on GHCR. armv7 failed with `FATAL: Argument '--armv7' unknown`: current home-assistant/builder releases dropped 32-bit ARM entirely (in line with HAOS dropping 32-bit ARM support upstream).

This removes armv7 from the publish matrix; armv7 installs keep building locally exactly as they do today.

**Decision needed before the `image:` flip** (flagged, not decided here): the `image:` key in config.yaml applies to all architectures, so flipping it would break armv7 installs (no armv7 image to pull). Options are (a) drop armv7 from the add-on's `arch:` list at the same time — defensible given HAOS itself dropped 32-bit ARM and Claude Code has no native armv7 build — or (b) don't flip and keep local builds for everyone. To be discussed on the flip PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak)_