### PR TITLE
v2.5.0 — pull prebuilt GHCR images; drop armv7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,14 +44,14 @@ curl -X GET http://localhost:7681/
 ### Add-on Structure (claude-terminal/)
 - **config.yaml** - Home Assistant add-on configuration (options schema, ingress, volume maps)
 - **Dockerfile** - Alpine-based image; all runtime packages (ttyd, tmux, nodejs, uv, ...) are baked in so startup never depends on the network
-- **build.yaml** - Multi-architecture build configuration (amd64, aarch64, armv7)
+- **build.yaml** - Multi-architecture build configuration (amd64, aarch64); images are prebuilt on GHCR and pulled by the Supervisor
 - **run.sh** - Startup script: environment/persistence setup, background Claude auto-update, ttyd launch
 - **scripts/** - Support scripts copied to `/opt/scripts/` (welcome banner, health check, HA context, MCP setup, persist-install, tmux config)
 
 ### Container Execution Flow
 1. `init_environment` — point HOME/XDG at `/data` (persistent), prepend `/data/home/.local/bin` to PATH, clean legacy npm cache, migrate old credentials
 2. `setup_commands` — install `welcome`, `persist-install`, `ha-context`, `claude-doctor` into `/usr/local/bin`
-3. `update_claude` — background install/update of the native Claude Code build into `/data` (skipped on armv7 or when `claude_auto_update: false`)
+3. `update_claude` — background install/update of the native Claude Code build into `/data` (skipped when `claude_auto_update: false`)
 4. `install_persistent_packages` — user-configured apk/pip packages
 5. `generate_ha_context` — background CLAUDE.md generation via Supervisor API
 6. `setup_ha_mcp` — register ha-mcp with `claude mcp add`
@@ -108,6 +108,6 @@ Note: `bashio::config` reads `/data/options.json`; outside a real Supervisor env
 - `npm_config_cache=/tmp/npm-cache` (image env — keeps caches out of HA backups)
 
 ### Important Constraints
-- Add-on targets Home Assistant OS (Alpine Linux base); armv7 has no native Claude Code builds
+- Add-on targets Home Assistant OS (Alpine Linux base); amd64 + aarch64 only (32-bit ARM dropped in 2.5.0)
 - Must handle credential/session persistence across container restarts
 - `/data` is included in HA backups — never let caches or reproducible artifacts accumulate there

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.5.0
+
+### 📦 Prebuilt images
+Installs and updates now pull prebuilt images from GHCR
+(`ghcr.io/heytcass/{arch}-addon-claude-terminal`) instead of building
+locally on your Home Assistant box. This means:
+- **No more build OOM failures on small systems** (#56)
+- **The add-on image is no longer exported into HA backups** — combined with
+  the 2.3.0 npm-cache fix, this fully resolves the backup bloat report (#103)
+- Much faster installs and updates
+
+### ⚠️ Breaking: armv7 (32-bit ARM) support dropped
+Home Assistant's builder and HAOS have dropped 32-bit ARM, and neither
+native Claude Code builds nor uv-managed Python exist for it. Existing
+armv7 installs keep working on 2.4.x but won't be offered this update.
+aarch64 (Raspberry Pi 3/4/5 on 64-bit HAOS) is fully supported.
+
+### 🛠️ Cleanup
+- Removed now-dead 32-bit ARM fallback paths from startup and MCP setup
+- Fixed the `image.source` label to point at this repository
+
 ## 2.4.0
 
 ### ✨ ha-mcp 3.5.1 → 7.11.0 (four major versions)

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -26,7 +26,7 @@ Your credentials are stored under `/data` and persist across restarts and add-on
 | `claude_extra_args` | `""` | Extra flags appended to every Claude launch, e.g. `--model claude-sonnet-5`. Values are split on spaces; quoted multi-word arguments are not supported. |
 | `ha_smart_context` | `true` | Generate a CLAUDE.md with your HA system info so Claude knows your setup. |
 | `enable_ha_mcp` | `true` | Register the [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) MCP server so Claude can control Home Assistant directly. |
-| `ha_mcp_version` | `"7.11.0"` | ha-mcp release to run. 32-bit ARM ignores this and stays on 3.5.1 (no Python 3.13 builds for that platform). |
+| `ha_mcp_version` | `"7.11.0"` | ha-mcp release to run. |
 | `persistent_apk_packages` | `[]` | APK packages reinstalled on every startup. |
 | `persistent_pip_packages` | `[]` | Python packages reinstalled on every startup. |
 

--- a/claude-terminal/README.md
+++ b/claude-terminal/README.md
@@ -25,7 +25,7 @@ This add-on runs Anthropic's [Claude Code](https://docs.anthropic.com/en/docs/cl
 - **HA Smart Context**: Claude automatically knows your HA version, entities, and add-ons
 - **Broad file access**: `/config`, `/addon_configs`, and `/share` are mounted
 - **Persistent packages**: `persist-install` keeps your extra apk/pip tools across restarts
-- **Multi-architecture**: amd64, aarch64, and armv7
+- **Multi-architecture**: amd64 and aarch64 (prebuilt images pulled from GHCR)
 
 ## Installation
 
@@ -47,7 +47,7 @@ Works out of the box. All options:
 | `claude_extra_args` | `""` | Extra flags for every Claude launch |
 | `ha_smart_context` | `true` | Generate HA context file for Claude |
 | `enable_ha_mcp` | `true` | Home Assistant MCP server integration |
-| `ha_mcp_version` | `"7.11.0"` | ha-mcp release to run (armv7 stays on 3.5.1) |
+| `ha_mcp_version` | `"7.11.0"` | ha-mcp release to run |
 | `persistent_apk_packages` | `[]` | APK packages to install on startup |
 | `persistent_pip_packages` | `[]` | pip packages to install on startup |
 

--- a/claude-terminal/build.yaml
+++ b/claude-terminal/build.yaml
@@ -1,10 +1,9 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.21
   amd64: ghcr.io/home-assistant/amd64-base:3.21
-  armv7: ghcr.io/home-assistant/armv7-base:3.21
 
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Claude Terminal"
   org.opencontainers.image.description: "Terminal interface for Anthropic's Claude Code CLI"
-  org.opencontainers.image.source: "https://github.com/anthropics/claude-code"
+  org.opencontainers.image.source: "https://github.com/heytcass/home-assistant-addons"
   org.opencontainers.image.licenses: "MIT"

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,15 +1,19 @@
 ---
 name: "Claude Terminal"
 description: "Web terminal with Anthropic's Claude Code CLI and persistent auth"
-version: "2.4.0"
+version: "2.5.0"
 slug: "claude_terminal"
 init: false
 
-# Supported architectures
+# Prebuilt images on GHCR — the Supervisor pulls these instead of building
+# locally (no build OOM, no image blobs in backups). Tag = version below.
+image: "ghcr.io/heytcass/{arch}-addon-claude-terminal"
+
+# Supported architectures (armv7 dropped in 2.5.0: HAOS dropped 32-bit ARM,
+# and neither Claude Code native builds nor managed Python exist for it)
 arch:
   - aarch64
   - amd64
-  - armv7
 
 # External resources
 url: "https://github.com/heytcass/home-assistant-addons"

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -136,14 +136,6 @@ update_claude() {
         return 0
     fi
 
-    # No native Claude Code builds exist for 32-bit ARM
-    case "$(uname -m)" in
-        armv7l|armv6l|armhf)
-            bashio::log.info "No native Claude Code builds for $(uname -m); using bundled copy"
-            return 0
-            ;;
-    esac
-
     if [ -x "$HOME/.local/bin/claude" ]; then
         bashio::log.info "Persistent Claude Code found; checking for updates in background"
         ("$HOME/.local/bin/claude" update >/dev/null 2>&1 || true) &

--- a/claude-terminal/scripts/setup-ha-mcp.sh
+++ b/claude-terminal/scripts/setup-ha-mcp.sh
@@ -32,37 +32,24 @@ configure_ha_mcp_server() {
     local version
     version=$(bashio::config 'ha_mcp_version' '7.11.0')
 
-    # ha-mcp >= 4.x requires CPython 3.13 exactly, which no Alpine release
-    # ships. uv provisions a managed musl 3.13 build instead (persisted under
-    # /data via XDG_DATA_HOME, so it downloads once). 32-bit ARM has no
-    # managed musl builds — stay on the last release that runs on the system
-    # Python 3.12 there.
-    local python_args=()
-    case "$(uname -m)" in
-        armv7l|armv6l|armhf)
-            version="3.5.1"
-            bashio::log.info "32-bit ARM detected - using ha-mcp ${version} on system Python"
-            ;;
-        *)
-            python_args=(--python 3.13)
-            ;;
-    esac
-
     # Remove existing ha-mcp configuration if present (to ensure clean state)
     claude mcp remove home-assistant 2>/dev/null || true
 
+    # ha-mcp >= 4.x requires CPython 3.13 exactly, which no Alpine release
+    # ships — uv provisions a managed musl 3.13 build (persisted under /data
+    # via XDG_DATA_HOME, so it downloads once).
     # --index-strategy unsafe-best-match: the HA wheels index doesn't carry
     # every version, so let uv consider all indexes (#77/#79)
     if claude mcp add home-assistant \
         --env "HOMEASSISTANT_URL=http://supervisor/core" \
         --env "HOMEASSISTANT_TOKEN=${SUPERVISOR_TOKEN}" \
-        -- uvx "${python_args[@]}" --index-strategy unsafe-best-match "ha-mcp@${version}"; then
+        -- uvx --python 3.13 --index-strategy unsafe-best-match "ha-mcp@${version}"; then
         bashio::log.info "ha-mcp ${version} configured for Claude Code"
 
         # Pre-warm the uv environment in the background (managed Python
         # download + dependency resolution) so the first MCP connection
         # doesn't hit the client startup timeout
-        (uvx "${python_args[@]}" --index-strategy unsafe-best-match \
+        (uvx --python 3.13 --index-strategy unsafe-best-match \
             --from "ha-mcp@${version}" python -c "" >/dev/null 2>&1 || true) &
         bashio::log.info "Pre-warming ha-mcp environment in background"
     else


### PR DESCRIPTION
Phase two of the prebuilt-image rollout. Both GHCR packages are **verified public** (anonymous manifest pulls return 200 for `amd64` and `aarch64` at tag 2.4.0).

## Changes

- **`image: "ghcr.io/heytcass/{arch}-addon-claude-terminal"`** in config.yaml — the Supervisor now pulls prebuilt images instead of building locally. Fixes #56 (build OOM on 4 GB systems) and completes the #103 backup-bloat fix (locally-built add-on images get exported into every backup; pulled images don't).
- **armv7 dropped** from `arch:` and build.yaml (owner-approved): HA's builder rejects `--armv7`, HAOS dropped 32-bit ARM, and neither native Claude Code builds nor uv-managed Python exist for it. Existing armv7 installs remain on 2.4.x (the Supervisor won't offer them this update).
- Removed the now-dead 32-bit ARM fallback branches from `run.sh` and `setup-ha-mcp.sh`; fixed the `image.source` label to point at this repo.

## Rollout sequencing

Merging this triggers the Publish Images workflow (config.yaml is under `claude-terminal/`), which builds and pushes the `2.5.0` tags. There's a short window between merge and publish completion where an update attempt would fail to pull — I'll verify the 2.5.0 manifests are live right after the workflow finishes and confirm before anyone should update.

## Testing

- shellcheck (CI flags) passes; config/build YAML validated
- Anonymous GHCR pulls verified for both arches at 2.4.0
- The 2.5.0 image pull path gets its real test on the owner's instance right after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZs3jRWq9UuTZsNBHDz8ak)_