### PR TITLE
fix(claude-terminal): fall back to bundled Claude when the native build can't run (musl posix_getdents)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.5.1
+
+### 🐛 Blank terminal when the persistent Claude build can't run
+On the Alpine 3.21 base image (musl 1.2.5), recent native Claude Code builds
+abort on launch with `Error relocating ...: posix_getdents: symbol not found`.
+Because the persistent install in `/data` is still executable, it kept
+shadowing the working bundled copy on `PATH` — and since ttyd launches
+`tmux new-session ... 'claude'`, the tmux session died the instant `claude`
+did, leaving users with a blank/immediately-closing terminal. Self-healing
+auto-update never recovered either, because updating requires running the
+broken binary.
+
+Startup now verifies the persistent build **actually runs** (not just that
+it's present and `+x`); if it can't, the broken install is removed so the
+bundled copy takes over and the terminal stays usable. This runs even when
+`claude_auto_update` is disabled (disabling updates never removed the broken
+binary), and a background `claude update` that pulls an unrunnable build is
+now re-validated and rolled back the same way.
+
 ## 2.5.0
 
 ### 📦 Prebuilt images

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal"
 description: "Web terminal with Anthropic's Claude Code CLI and persistent auth"
-version: "2.5.0"
+version: "2.5.1"
 slug: "claude_terminal"
 init: false
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -130,26 +130,78 @@ setup_commands() {
 # time, so install the official native build into /data (persists across
 # restarts and add-on updates) and refresh it in the background on each
 # boot. Approach adapted from #104 by @WKassebaum.
+# A native install being executable (-x) is not the same as it being
+# runnable. The native build is dynamically linked, so a libc symbol
+# mismatch — e.g. the Alpine base image's musl lacking `posix_getdents`,
+# which recent Claude Code builds relocate against — makes the binary abort
+# on launch with a relocation error even though the file is present and +x.
+# Such a binary still wins on PATH over the bundled copy and takes the whole
+# terminal down with it (ttyd runs `tmux new-session ... 'claude'`, so the
+# tmux session dies the instant claude does). Treat "installed" and
+# "actually runs" as separate facts.
+native_claude_runs() {
+    "$HOME/.local/bin/claude" --version >/dev/null 2>&1
+}
+
+# Remove a persistent native install that exists but cannot execute in this
+# image (typically a libc mismatch), so it stops shadowing the working
+# bundled copy at /usr/local/bin/claude on PATH. This must run regardless of
+# the auto-update setting — a broken +x binary is what takes the terminal
+# down, and disabling auto-update does not remove it. Returns 0 if a usable
+# native install remains, 1 otherwise.
+ensure_native_claude_usable() {
+    [ -x "$HOME/.local/bin/claude" ] || return 1
+    if native_claude_runs; then
+        return 0
+    fi
+    bashio::log.warning "Persistent Claude Code is present but fails to run (likely a libc mismatch); removing it and falling back to the bundled copy"
+    rm -f "$HOME/.local/bin/claude"
+    return 1
+}
+
 update_claude() {
+    # Always neutralise a broken persistent install first, even when
+    # auto-update is off, so it can't keep shadowing the bundled copy.
+    # Capture via `|| native_usable=$?` so the intentional non-zero return
+    # (no/removed native install) doesn't trip `set -e` and abort startup.
+    local native_usable=0
+    ensure_native_claude_usable || native_usable=$?
+
     if [ "$(bashio::config 'claude_auto_update' 'true')" != "true" ]; then
-        bashio::log.info "Claude auto-update disabled; using bundled Claude Code"
+        if [ "$native_usable" -eq 0 ]; then
+            bashio::log.info "Claude auto-update disabled; using persistent Claude Code"
+        else
+            bashio::log.info "Claude auto-update disabled; using bundled Claude Code"
+        fi
         return 0
     fi
 
-    if [ -x "$HOME/.local/bin/claude" ]; then
+    if [ "$native_usable" -eq 0 ]; then
         bashio::log.info "Persistent Claude Code found; checking for updates in background"
-        ("$HOME/.local/bin/claude" update >/dev/null 2>&1 || true) &
-    else
-        bashio::log.info "Installing persistent Claude Code into /data (background)..."
         (
-            if curl -fsSL --connect-timeout 10 https://claude.ai/install.sh | bash >/dev/null 2>&1 \
-                && [ -x "$HOME/.local/bin/claude" ]; then
-                bashio::log.info "Persistent Claude Code installed: $("$HOME/.local/bin/claude" --version 2>/dev/null || echo 'version unknown')"
-            else
-                bashio::log.warning "Native Claude Code install failed; using bundled copy for now"
+            "$HOME/.local/bin/claude" update >/dev/null 2>&1 || true
+            # An update can pull a build this image's libc can't run; don't
+            # let it linger on PATH for the next launch or reconnect.
+            if [ -x "$HOME/.local/bin/claude" ] && ! native_claude_runs; then
+                bashio::log.warning "Updated Claude Code no longer runs in this image; removing it and falling back to the bundled copy"
+                rm -f "$HOME/.local/bin/claude"
             fi
         ) &
+        return 0
     fi
+
+    bashio::log.info "Installing persistent Claude Code into /data (background)..."
+    (
+        if curl -fsSL --connect-timeout 10 https://claude.ai/install.sh | bash >/dev/null 2>&1 \
+            && [ -x "$HOME/.local/bin/claude" ] && native_claude_runs; then
+            bashio::log.info "Persistent Claude Code installed: $("$HOME/.local/bin/claude" --version 2>/dev/null || echo 'version unknown')"
+        else
+            # Don't let a freshly installed but unrunnable binary shadow the
+            # bundled copy either.
+            rm -f "$HOME/.local/bin/claude"
+            bashio::log.warning "Native Claude Code install unavailable or unrunnable; using bundled copy"
+        fi
+    ) &
 }
 
 # Install persistent packages from config and saved state


### PR DESCRIPTION
## Problem

On the Alpine 3.21 base image (musl **1.2.5**), recent native Claude Code builds abort the moment they launch:

```
Error relocating /data/home/.local/bin/claude: posix_getdents: symbol not found
```

`posix_getdents` is a newer musl symbol the native binaries now relocate against, and 3.21's musl doesn't provide it. The failure is quiet and total:

- The persistent install in `/data` is still an executable file, so the `[ -x "$HOME/.local/bin/claude" ]` check passes and it keeps winning on `PATH` over the working bundled copy at `/usr/local/bin/claude`.
- ttyd runs `tmux new-session -A -s claude 'claude'`, so when `claude` aborts on startup the tmux session dies with it — the user gets a **blank / immediately-closing terminal**.
- Self-healing auto-update can't recover, because `claude update` has to *run* the broken binary to update it.

I hit this on a live install (native `2.1.77` in `/data` broken; bundled `2.1.204` runs fine on the same musl). All three cached native versions failed identically; the bundled copy was never reached because the broken symlink shadowed it.

## Fix

Treat "installed" and "actually runs" as separate facts. `update_claude` now verifies the persistent build with `claude --version` before trusting it:

- If it runs → behave as before (background `claude update`).
- If it doesn't → remove the broken `$HOME/.local/bin/claude` so the bundled copy takes over and the terminal stays usable. A later boot re-installs once a compatible build exists.
- Same runnability guard applied after a fresh native install, so a freshly-installed-but-unrunnable binary can't shadow the bundled copy either.

Arch-agnostic and needs no base-image bump. (A base image with musl ≥ 1.2.6 would also resolve the root cause, but the runtime guard fixes the user-facing breakage for everyone and is defensive against future libc drift.)

## Changes
- `claude-terminal/run.sh`: add `native_claude_runs()`; guard the native path in `update_claude()` with fallback to the bundled copy.
- `claude-terminal/config.yaml`: `2.5.0` -> `2.5.1`
- `claude-terminal/CHANGELOG.md`: 2.5.1 entry

## Testing
- `bash -n run.sh` passes.
- On the affected install, manually clearing the broken native install made `claude` resolve to bundled `/usr/local/bin/claude` (`2.1.204`) and a `tmux new-session ... 'claude'` session stays alive instead of closing instantly. This patch automates that recovery on boot.

> Draft: I don't have a multi-arch build set up to test the aarch64 image, so I'm marking this draft pending your CI / a second pair of eyes on the fallback logic. Happy to adjust the approach (e.g. base-image bump instead) if you'd prefer.
