### PR TITLE
fix(claude-terminal): unblock aarch64 builds (native binary fetch), timeout guard, changelog fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ curl -X GET http://localhost:7681/
 ### Key Design Rules
 - **Nothing on the boot path may hit the network or block on input.** Network work (updates, context generation) is backgrounded; packages ship in the image.
 - **Everything persistent lives in `/data`** (HOME is `/data/home`). The container filesystem is recreated on every restart.
-- **Two Claude copies exist**: the npm copy baked into the image (fallback, frozen at build time) and the native install in `/data/home/.local/bin` (persists, self-updates, wins via PATH).
+- **Two Claude copies exist**: the native musl binary baked into the image at `/usr/local/bin/claude` (fallback, frozen at build time, fetched straight from the npm registry — no npm/Node during build, which crashes under QEMU in aarch64 CI builds) and the native install in `/data/home/.local/bin` (persists, self-updates, wins via PATH).
 - **No custom session UI.** tmux `new-session -A` handles reconnects; Claude Code's own `-c`/`-r` handle continue/resume.
 
 ## Development Notes

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 2.5.1
 
 ### 🐛 Blank terminal when the persistent Claude build can't run
-On the Alpine 3.21 base image (musl 1.2.5), recent native Claude Code builds
-abort on launch with `Error relocating ...: posix_getdents: symbol not found`.
+On containers built from older Alpine bases (musl < 1.2.5, which lacks
+`posix_getdents`), recent native Claude Code builds abort on launch with
+`Error relocating ...: posix_getdents: symbol not found` (#112).
 Because the persistent install in `/data` is still executable, it kept
 shadowing the working bundled copy on `PATH` — and since ttyd launches
 `tmux new-session ... 'claude'`, the tmux session died the instant `claude`
@@ -18,6 +19,9 @@ bundled copy takes over and the terminal stays usable. This runs even when
 `claude_auto_update` is disabled (disabling updates never removed the broken
 binary), and a background `claude update` that pulls an unrunnable build is
 now re-validated and rolled back the same way.
+
+Contributed by [@JoshDev](https://github.com/JoshDev) (#117); thanks
+[@Dezent](https://github.com/Dezent) for the diagnosis in #112.
 
 ## 2.5.0
 

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -23,6 +23,15 @@ now re-validated and rolled back the same way.
 Contributed by [@JoshDev](https://github.com/JoshDev) (#117); thanks
 [@Dezent](https://github.com/Dezent) for the diagnosis in #112.
 
+### 🔧 Bundled Claude now installed as a native binary at build time
+The `@anthropic-ai/claude-code` npm package has become a thin wrapper that
+just installs the platform's native binary, and running npm/Node during
+QEMU-emulated aarch64 image builds started crashing CI. The Dockerfile now
+downloads the native musl binary directly from the npm registry (curl+tar,
+no Node involved) and places it at `/usr/local/bin/claude`. Same
+"latest at build time" behavior, smaller image, and aarch64 images build
+reliably again.
+
 ## 2.5.0
 
 ### 📦 Prebuilt images

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -36,11 +36,27 @@ ENV npm_config_cache=/tmp/npm-cache
 # environment declares itself a disposable container — which HA add-ons are
 ENV IS_SANDBOX=1
 
+# The HA base image already runs ash with pipefail; restate it so hadolint
+# (which only sees this file) knows the curl|tar pipe below is guarded
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
 # Bundled Claude Code CLI. This copy is frozen at image build time; when
 # claude_auto_update is enabled, run.sh maintains a persistent native install
 # in /data that takes precedence and keeps itself current.
-RUN npm install -g @anthropic-ai/claude-code@latest \
-    && npm cache clean --force
+# Fetched as the native musl binary straight from the npm registry rather
+# than via `npm install -g`: the npm package is now only a wrapper that
+# installs this same binary, and running npm/Node during aarch64 cross-builds
+# (QEMU on CI runners) crashes V8 with SIGILL. curl+tar emulate fine.
+RUN case "$(apk --print-arch)" in \
+        x86_64)  claude_pkg="linux-x64-musl" ;; \
+        aarch64) claude_pkg="linux-arm64-musl" ;; \
+        *) echo "Unsupported architecture: $(apk --print-arch)" >&2; exit 1 ;; \
+    esac \
+    && claude_version="$(curl -fsSL https://registry.npmjs.org/@anthropic-ai/claude-code/latest | jq -r .version)" \
+    && curl -fsSL "https://registry.npmjs.org/@anthropic-ai/claude-code-${claude_pkg}/-/claude-code-${claude_pkg}-${claude_version}.tgz" \
+        | tar -xz -C /tmp package/claude \
+    && install -m 0755 /tmp/package/claude /usr/local/bin/claude \
+    && rm -rf /tmp/package
 
 WORKDIR /config
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -42,7 +42,7 @@ init_environment() {
     export ANTHROPIC_HOME="/data"
 
     # The persistent native Claude install (see update_claude) must win over
-    # the npm copy bundled in the image
+    # the copy bundled in the image
     export PATH="$data_home/.local/bin:$PATH"
 
     # Older versions let the npm cache pile up here, inflating HA backups by
@@ -126,7 +126,7 @@ setup_commands() {
         || echo "unknown" > /opt/scripts/addon-version
 }
 
-# Keep Claude Code current. The npm copy in the image is frozen at build
+# Keep Claude Code current. The bundled copy in the image is frozen at build
 # time, so install the official native build into /data (persists across
 # restarts and add-on updates) and refresh it in the background on each
 # boot. Approach adapted from #104 by @WKassebaum.

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -132,15 +132,16 @@ setup_commands() {
 # boot. Approach adapted from #104 by @WKassebaum.
 # A native install being executable (-x) is not the same as it being
 # runnable. The native build is dynamically linked, so a libc symbol
-# mismatch — e.g. the Alpine base image's musl lacking `posix_getdents`,
+# mismatch — e.g. an older base image's musl lacking `posix_getdents`,
 # which recent Claude Code builds relocate against — makes the binary abort
 # on launch with a relocation error even though the file is present and +x.
 # Such a binary still wins on PATH over the bundled copy and takes the whole
 # terminal down with it (ttyd runs `tmux new-session ... 'claude'`, so the
 # tmux session dies the instant claude does). Treat "installed" and
-# "actually runs" as separate facts.
+# "actually runs" as separate facts. The timeout keeps a wedged binary from
+# blocking the boot path (this check runs before ttyd starts).
 native_claude_runs() {
-    "$HOME/.local/bin/claude" --version >/dev/null 2>&1
+    timeout 10 "$HOME/.local/bin/claude" --version >/dev/null 2>&1
 }
 
 # Remove a persistent native install that exists but cannot execute in this


### PR DESCRIPTION
## What

Follow-up to #117 (merged), now also carrying the fix for the aarch64 CI/publish breakage that surfaced when #117 merged. Three changes:

1. **Unblock aarch64 image builds / the 2.5.1 publish.** `Build (aarch64)` on PRs and `Publish (aarch64)` on main both fail with `Illegal instruction (core dumped)` inside `RUN npm install -g @anthropic-ai/claude-code@latest` — npm/Node (V8 JIT) crashing under QEMU emulation. The same Dockerfile built green on July 17; the runner's QEMU stack drifted, and the npm package is now a thin wrapper whose install pulls a large platform-native binary through npm anyway. The Dockerfile now downloads the native **musl** binary for the target arch directly from the npm registry (curl+tar — no Node executes during the build) and installs it at `/usr/local/bin/claude`, same path as before. "Latest at build time" semantics are preserved (version resolved from the registry at build), and the image shrinks. `npm`/`node` remain in the image for interactive use.
2. **Timeout on the boot-path runnability probe** (from #117 review): `native_claude_runs()` uses `timeout 10 ...` so a wedged persistent binary can't block startup before ttyd launches.
3. **Changelog corrections**: `posix_getdents` was *added* in musl 1.2.5 (the current `:3.21` base ships it) — the failure hits containers built from older Alpine bases; entry now says so, references #112, and credits [@JoshDev](https://github.com/JoshDev) (#117) and [@Dezent](https://github.com/Dezent) (diagnosis in #112) per the repo's changelog conventions. Stale "npm copy" wording in `run.sh` comments and `CLAUDE.md` updated to match the new install method.

## Testing

- Simulated the exact Dockerfile fetch pipeline for `linux-x64-musl`: resolves latest (2.1.218), extracts `package/claude`, yields a valid musl-linked ELF; both `linux-x64-musl` and `linux-arm64-musl` registry URLs return 200.
- `bash -n` + repo shellcheck invocation clean on `run.sh` and all scripts.
- No binary is executed during the build (deliberately — that would reintroduce the QEMU crash class), so the amd64 smoke tests + run.sh's new runnability guard cover the runtime side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LMWV7TH6jtHu3nG1GUXQL