### PR TITLE
fix(claude-terminal): claude-login-url misses URL tail on hard-wrapped output

### DIFF
--- a/claude-terminal/scripts/claude-login-url.sh
+++ b/claude-terminal/scripts/claude-login-url.sh
@@ -8,14 +8,29 @@
 # Why: the browser terminal's OSC 52 clipboard path truncates long payloads
 # (~400 chars), and Claude Code's login URL is ~450+ chars — the tail (the
 # `state` parameter) gets cut off, which makes authorization fail with
-# "Invalid request format". capture-pane with -J joins soft-wrapped lines,
-# so the URL comes out intact regardless of terminal width.
+# "Invalid request format".
+#
+# Claude Code's own UI hard-wraps the URL across multiple physical lines
+# (real line breaks from its own rendering, not the terminal's soft-wrap),
+# so a single-line grep only ever captures the first fragment. Reassemble it
+# by reading every line from the most recent "https://..." start through the
+# next blank line and concatenating them — the CLI wraps mid-token with no
+# separator, so lines are joined with no space between them.
 
 OUT="${1:-/config/claude-login-url.txt}"
 
-url=$(tmux capture-pane -p -J -t claude -S -500 2>/dev/null \
-    | grep -oE "https://(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)[^[:space:]\"'\`)<>]*" \
-    | tail -1)
+url=$(tmux capture-pane -p -J -t claude -S -500 2>/dev/null | awk '
+    /^https:\/\/(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)/ {
+        url = $0
+        collecting = 1
+        next
+    }
+    collecting {
+        if (NF == 0) { collecting = 0 }
+        else { url = url $0 }
+    }
+    END { print url }
+')
 
 if [ -z "$url" ]; then
     echo "No login URL found in the Claude session." >&2


### PR DESCRIPTION
## Problem

\`claude-login-url\` (added in #106/#107 to work around the OSC 52 clipboard
truncation on the OAuth login URL) silently truncates the URL itself in
current Claude Code versions.

Claude Code's login screen now hard-wraps the URL across multiple physical
lines using real line breaks from its own UI rendering, not the terminal's
soft-wrap. `tmux capture-pane -J` only rejoins tmux's own soft-wrap
artifacts — it does nothing for lines the app itself terminated with a
newline. Since `grep -oE` is line-based, it only ever captured the first
physical line of the URL, silently dropping the rest (including the
trailing `state` parameter), which breaks authorization the same way the
original clipboard truncation did.

## Fix

Reassemble the URL by reading every line from the most recent
`https://...` start through the next blank line and concatenating them
(Claude Code wraps mid-token with no separator, so lines are joined with no
space between them).

## Testing

Verified live against a running instance: captured the raw tmux pane output
showing the URL split across 3 physical lines, confirmed the old
`grep`-based extraction only returned the first ~220 characters, and
confirmed the new awk-based extraction reconstructs the full, correct
450-character URL matching the actual rendered `state` parameter.