### PR TITLE
feat(claude-terminal): auto-deliver login URL as HA notification

### DIFF
--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -110,7 +110,8 @@ setup_commands() {
         "persist-install:/opt/scripts/persist-install.sh" \
         "ha-context:/opt/scripts/ha-context.sh" \
         "claude-doctor:/opt/scripts/health-check.sh" \
-        "claude-login-url:/opt/scripts/claude-login-url.sh"; do
+        "claude-login-url:/opt/scripts/claude-login-url.sh" \
+        "login-url-watcher:/opt/scripts/login-url-watcher.sh"; do
         name="${entry%%:*}"
         script="${entry#*:}"
         if [ -f "$script" ]; then
@@ -284,6 +285,17 @@ generate_ha_context() {
     fi
 }
 
+# Deliver Claude Code's OAuth login URL as a clickable HA notification the
+# moment it appears, so login works with no manual steps (SSH, File Editor,
+# clipboard) needed — see login-url-watcher.sh for why the clipboard path
+# can't be relied on.
+start_login_url_watcher() {
+    if [ -f /usr/local/bin/login-url-watcher ]; then
+        bashio::log.info "Starting login URL watcher in background"
+        (/usr/local/bin/login-url-watcher >/dev/null 2>&1 || true) &
+    fi
+}
+
 # Build extra flags for every claude launch.
 # Note: the value is word-split; quoted multi-word arguments are not
 # re-parsed (documented limitation).
@@ -376,6 +388,7 @@ main() {
     update_claude
     install_persistent_packages
     generate_ha_context
+    start_login_url_watcher
     setup_ha_mcp
     start_web_terminal
 }

--- a/claude-terminal/scripts/login-url-watcher.sh
+++ b/claude-terminal/scripts/login-url-watcher.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# login-url-watcher — background loop that detects Claude Code's OAuth login
+# URL and delivers it as a clickable Home Assistant persistent notification.
+#
+# Why: the browser terminal's "c to copy" never reliably reaches the OS
+# clipboard. Claude Code emits the OSC 52 copy escape sequence twice per
+# keypress; tmux's relay of both copies races the browser's async Clipboard
+# API, and the write silently never completes. That's true even with tmux
+# and the browser fully correctly configured — see claude-login-url.sh for
+# the SSH-based fallback this reuses the same extraction logic from. Rather
+# than depend on SSH being enabled, this watches for the URL automatically
+# and surfaces it in the HA UI directly, with no manual steps.
+#
+# Runs as a background loop for the life of the container (started once from
+# run.sh); cheap when idle since it only polls a local tmux pane.
+
+NOTIFICATION_ID="claude_login_url"
+POLL_INTERVAL=3
+
+extract_url() {
+    tmux capture-pane -p -J -t claude -S -500 2>/dev/null | awk '
+        /^https:\/\/(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)/ {
+            url = $0
+            collecting = 1
+            next
+        }
+        collecting {
+            if (NF == 0) { collecting = 0 }
+            else { url = url $0 }
+        }
+        END { print url }
+    '
+}
+
+is_logged_in() {
+    local cred="$HOME/.claude/.credentials.json"
+    [ -f "$cred" ] || return 1
+    local expires_at
+    expires_at=$(jq -r '.claudeAiOauth.expiresAt // empty' "$cred" 2>/dev/null)
+    [ -n "$expires_at" ] && [ "$expires_at" -gt "$(($(date +%s) * 1000))" ] 2>/dev/null
+}
+
+notify() {
+    local url="$1"
+    curl -s -X POST \
+        -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg msg "[Click here to authorize Claude Code]($url)
+
+If it doesn't open the right app, copy this link instead:
+$url" --arg id "$NOTIFICATION_ID" \
+            '{title: "Claude Code login", message: $msg, notification_id: $id}')" \
+        http://supervisor/core/api/services/persistent_notification/create >/dev/null 2>&1
+}
+
+dismiss() {
+    curl -s -X POST \
+        -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg id "$NOTIFICATION_ID" '{notification_id: $id}')" \
+        http://supervisor/core/api/services/persistent_notification/dismiss >/dev/null 2>&1
+}
+
+last_url=""
+notified=0
+
+while true; do
+    if tmux has-session -t claude 2>/dev/null; then
+        if is_logged_in; then
+            if [ "$notified" = "1" ]; then
+                dismiss
+                notified=0
+                last_url=""
+            fi
+        else
+            url=$(extract_url)
+            if [ -n "$url" ] && [ "$url" != "$last_url" ]; then
+                notify "$url"
+                last_url="$url"
+                notified=1
+            fi
+        fi
+    fi
+    sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Problem

The browser terminal's "c to copy" for the OAuth login URL can't be relied
on. Instrumenting the live xterm.js clipboard handler (registering an
additional OSC 52 handler and wrapping `navigator.clipboard.writeText`
directly) shows Claude Code emits the OSC 52 copy escape sequence *twice*
per keypress — confirmed straight from the raw pty output via
`tmux pipe-pane`, independent of any tmux/ttyd config. The two copies race
tmux's relay and the browser's async Clipboard API handler resolution, and
`clipboard.writeText()` silently never gets called at all (not an error —
verified with a spy on the actual function reference). This reproduces with
`set-clipboard`, `allow-passthrough`, and the `Ms` terminal-override all
correctly configured, in an unsandboxed, non-iframed, secure-context (HTTPS)
tab, with clipboard permission explicitly granted — so it isn't fixable
from tmux/ttyd config on the add-on side.

`claude-login-url` (see the companion PR fixing its hard-wrap bug) is a
solid fallback, but it requires `enable_ssh` to be on and a manual
multi-step flow (SSH in, run the command, open the file via File Editor/
Samba, copy, paste). Most users won't have SSH enabled.

## Fix

Add a background watcher, started for every container (no opt-in needed),
that polls the `claude` tmux pane and, the moment a login URL appears,
delivers it as a clickable Home Assistant persistent notification — no
SSH, no File Editor, no clipboard involved. It dismisses itself once login
succeeds (checked via the OAuth credentials file, not by inferring from the
pane text).

## Testing

Verified live: triggered `/login`, confirmed the watcher's background poll
picked up the new URL and posted a "Claude Code login" persistent
notification with a working `[Click here to authorize Claude Code](url)`
link, visible in the HA notification panel — matching the exact URL the
terminal displayed.