### PR TITLE
fix(claude-terminal): never let a wedged claude binary block startup; warn on missing AVX

### DIFF
--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -194,7 +194,13 @@ update_claude() {
 
     bashio::log.info "Installing persistent Claude Code into /data (background)..."
     (
-        if curl -fsSL --connect-timeout 10 https://claude.ai/install.sh | bash >/dev/null 2>&1 \
+        # Download the installer to a file instead of `curl | bash`: with the
+        # pipe, the claude binary the script launches inherits that pipe as
+        # stdin and can block forever reading from it once curl exits (#126).
+        # A file plus stdin from /dev/null gives every child a closed stdin.
+        installer=$(mktemp /tmp/claude-install.XXXXXX.sh)
+        if curl -fsSL --connect-timeout 10 https://claude.ai/install.sh -o "$installer" \
+            && bash "$installer" </dev/null >/dev/null 2>&1 \
             && [ -x "$HOME/.local/bin/claude" ] && native_claude_runs; then
             bashio::log.info "Persistent Claude Code installed: $("$HOME/.local/bin/claude" --version 2>/dev/null || echo 'version unknown')"
         else
@@ -203,7 +209,19 @@ update_claude() {
             rm -f "$HOME/.local/bin/claude"
             bashio::log.warning "Native Claude Code install unavailable or unrunnable; using bundled copy"
         fi
+        rm -f "$installer"
     ) &
+}
+
+# Claude Code's runtime (Bun) requires AVX on x86-64. Hypervisor default CPU
+# types (Proxmox/QEMU kvm64, qemu64) mask it even when the host CPU has it,
+# and every claude invocation then crashes or spins at 100% CPU (#126).
+# Warn in the add-on log, since the terminal itself is unusable in that state.
+check_cpu_features() {
+    if [ "$(uname -m)" = "x86_64" ] && ! grep -q avx /proc/cpuinfo; then
+        bashio::log.warning "This CPU does not expose AVX — Claude Code will likely hang or crash on every invocation"
+        bashio::log.warning "On a Proxmox/QEMU VM, set the VM's CPU type to 'host', then fully shut the VM down and start it again (a reboot is not enough)"
+    fi
 }
 
 # Install persistent packages from config and saved state
@@ -384,6 +402,7 @@ main() {
     bashio::log.info "Starting Claude Terminal add-on..."
 
     init_environment
+    check_cpu_features
     setup_commands
     update_claude
     install_persistent_packages

--- a/claude-terminal/scripts/health-check.sh
+++ b/claude-terminal/scripts/health-check.sh
@@ -27,6 +27,32 @@ check_system_resources() {
     fi
 }
 
+check_cpu_capabilities() {
+    bashio::log.info "=== CPU Capability Check ==="
+
+    # Claude Code's runtime (Bun) requires AVX on x86-64. Hypervisor default
+    # CPU types (Proxmox/QEMU kvm64, qemu64) mask it even when the physical
+    # CPU has it, and every claude invocation then crashes or spins at 100%
+    # CPU with no output (#126). Not applicable on aarch64.
+    if [ "$(uname -m)" != "x86_64" ]; then
+        bashio::log.info "Architecture $(uname -m): AVX check not applicable ✓"
+        return 0
+    fi
+
+    if grep -q avx /proc/cpuinfo; then
+        bashio::log.info "CPU exposes AVX ✓"
+    else
+        bashio::log.error "CPU does not expose AVX ✗"
+        bashio::log.info "Claude Code's runtime (Bun) requires AVX; without it every"
+        bashio::log.info "claude invocation hangs at 100% CPU or crashes with SIGILL."
+        bashio::log.info "On a VM this usually means the hypervisor hides the host CPU:"
+        bashio::log.info "  • Proxmox/QEMU: set the VM's CPU type to 'host' (not kvm64/qemu64),"
+        bashio::log.info "    then fully shut the VM down and start it (a reboot is not enough)"
+        bashio::log.info "  • Other hypervisors: enable host CPU passthrough"
+        return 1
+    fi
+}
+
 check_directory_permissions() {
     bashio::log.info "=== Directory Permissions Check ==="
 
@@ -141,6 +167,7 @@ run_diagnostics() {
     local errors=0
 
     check_system_resources || ((errors++))
+    check_cpu_capabilities || ((errors++))
     check_directory_permissions || ((errors++))
     check_node_installation || ((errors++))
     check_claude_cli || ((errors++))
@@ -183,6 +210,9 @@ run_diagnostics() {
             bashio::log.info ""
             bashio::log.info "=== Virtual Environment Detected (Possibly Proxmox) ==="
             bashio::log.info "If running in Proxmox, ensure:"
+            bashio::log.info "  • VM CPU type is 'host' — the default kvm64/qemu64 types hide"
+            bashio::log.info "    AVX, which Claude Code requires (see CPU Capability Check above);"
+            bashio::log.info "    apply with a full VM shutdown + start, not a reboot"
             bashio::log.info "  • VM has sufficient resources (2GB+ RAM)"
             bashio::log.info "  • Network device uses VirtIO (recommended)"
             bashio::log.info "  • Firewall rules allow container registry access"

--- a/claude-terminal/scripts/setup-ha-mcp.sh
+++ b/claude-terminal/scripts/setup-ha-mcp.sh
@@ -32,15 +32,19 @@ configure_ha_mcp_server() {
     local version
     version=$(bashio::config 'ha_mcp_version' '7.11.0')
 
-    # Remove existing ha-mcp configuration if present (to ensure clean state)
-    claude mcp remove home-assistant 2>/dev/null || true
+    # Remove existing ha-mcp configuration if present (to ensure clean state).
+    # Both claude calls below run on the boot path, so they must never block
+    # startup: a claude binary that wedges (e.g. spinning at 100% CPU on a VM
+    # whose virtual CPU masks AVX, #126) would otherwise hang the add-on at
+    # "Setting up ha-mcp" forever. These are local config edits — 30s is ample.
+    timeout 30 claude mcp remove home-assistant 2>/dev/null || true
 
     # ha-mcp >= 4.x requires CPython 3.13 exactly, which no Alpine release
     # ships — uv provisions a managed musl 3.13 build (persisted under /data
     # via XDG_DATA_HOME, so it downloads once).
     # --index-strategy unsafe-best-match: the HA wheels index doesn't carry
     # every version, so let uv consider all indexes (#77/#79)
-    if claude mcp add home-assistant \
+    if timeout 30 claude mcp add home-assistant \
         --env "HOMEASSISTANT_URL=http://supervisor/core" \
         --env "HOMEASSISTANT_TOKEN=${SUPERVISOR_TOKEN}" \
         -- uvx --python 3.13 --index-strategy unsafe-best-match "ha-mcp@${version}"; then


### PR DESCRIPTION
## Problem

#126: on a Proxmox VM whose default CPU type (`kvm64`/`qemu64`) masks AVX, every `claude` invocation spins at 100% CPU — Claude Code's Bun runtime requires AVX (upstream: anthropics/claude-code#19904, #19981, #22240). That's an environment problem with a one-line hypervisor fix (CPU type → `host`), but it exposed three add-on weaknesses:

1. `setup-ha-mcp.sh` ran `claude mcp remove`/`claude mcp add` **foreground on the boot path with no timeout**, so a wedged binary hung the add-on forever at "Setting up ha-mcp" — violating the design rule that nothing on the boot path may block. The 2.5.1 runnability probe only guards the installer path.
2. The native installer ran via `curl | bash`, so the claude binary it launches inherited the script pipe as stdin and could block forever reading it (the orphaned-pipe hang dissected in #126).
3. Nothing anywhere named the actual problem or its fix to the user.

## Fix

- **setup-ha-mcp.sh**: wrap both boot-path `claude mcp` calls in `timeout 30` (local config edits; ample). Worst case the add-on now boots with a warning instead of hanging.
- **run.sh**: download the installer to a temp file and run it with stdin from `/dev/null`; clean the file up after.
- **run.sh**: `check_cpu_features` logs an early startup warning on x86-64 without AVX, naming the Proxmox `CPU type = host` + full-stop/start fix — the add-on log is the only place the user can still see when the terminal is unusable.
- **health-check.sh** (`claude-doctor`): new CPU Capability Check (x86-64 only; skipped on aarch64) with the same guidance, and the existing Proxmox advice section now leads with the CPU-type fix.

## Testing

- `shellcheck -s bash -S warning` clean on run.sh and all scripts (CI flags); `bash -n` clean.
- AVX grep verified against a live `/proc/cpuinfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG)_