### PR TITLE
fix(claude-terminal): find the login URL when it is indented or bordered

### DIFF
--- a/claude-terminal/scripts/claude-login-url.sh
+++ b/claude-terminal/scripts/claude-login-url.sh
@@ -16,18 +16,27 @@
 # by reading every line from the most recent "https://..." start through the
 # next blank line and concatenating them — the CLI wraps mid-token with no
 # separator, so lines are joined with no space between them.
+#
+# The URL is located anywhere on the line rather than anchored at column 0,
+# and every fragment is reduced to its run of URL characters: Claude Code may
+# render the login prompt indented or inside a bordered panel, and that
+# indentation (or border) would otherwise either defeat the match entirely or
+# be spliced into the middle of the reassembled URL.
 
 OUT="${1:-/config/claude-login-url.txt}"
 
 url=$(tmux capture-pane -p -J -t claude -S -500 2>/dev/null | awk '
-    /^https:\/\/(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)/ {
-        url = $0
+    $0 ~ /https:\/\/(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)/ {
+        match($0, /https:\/\/[A-Za-z0-9._~:\/?#@!$&()*+,;=%-]*/)
+        url = substr($0, RSTART, RLENGTH)
         collecting = 1
         next
     }
     collecting {
         if (NF == 0) { collecting = 0 }
-        else { url = url $0 }
+        else if (match($0, /[A-Za-z0-9._~:\/?#@!$&()*+,;=%-]+/)) {
+            url = url substr($0, RSTART, RLENGTH)
+        }
     }
     END { print url }
 ')

--- a/claude-terminal/scripts/login-url-watcher.sh
+++ b/claude-terminal/scripts/login-url-watcher.sh
@@ -14,20 +14,28 @@
 #
 # Runs as a background loop for the life of the container (started once from
 # run.sh); cheap when idle since it only polls a local tmux pane.
+#
+# The URL is located anywhere on the line rather than anchored at column 0,
+# and every fragment is reduced to its run of URL characters, so an indented
+# or bordered login prompt neither defeats the match nor splices stray
+# characters into the middle of the reassembled URL.
 
 NOTIFICATION_ID="claude_login_url"
 POLL_INTERVAL=3
 
 extract_url() {
     tmux capture-pane -p -J -t claude -S -500 2>/dev/null | awk '
-        /^https:\/\/(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)/ {
-            url = $0
+        $0 ~ /https:\/\/(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)/ {
+            match($0, /https:\/\/[A-Za-z0-9._~:\/?#@!$&()*+,;=%-]*/)
+            url = substr($0, RSTART, RLENGTH)
             collecting = 1
             next
         }
         collecting {
             if (NF == 0) { collecting = 0 }
-            else { url = url $0 }
+            else if (match($0, /[A-Za-z0-9._~:\/?#@!$&()*+,;=%-]+/)) {
+                url = url substr($0, RSTART, RLENGTH)
+            }
         }
         END { print url }
     '


### PR DESCRIPTION
## Problem

The login URL extraction added in #123/#124 anchors its match at column 0:

```awk
/^https:\/\/(claude\.(com|ai)|...)/ { ... }
```

If Claude Code renders the login prompt **indented** or **inside a bordered panel**, that anchor matches nothing at all — the watcher never posts its notification, and `claude-login-url` reports "No login URL found in the Claude session." Both failure modes are silent from the user's side.

Un-anchoring alone would not have been enough: the *continuation* lines carry the same indentation or border, and the reassembly concatenates them verbatim, so the leading spaces (or `│`) would be spliced into the middle of the URL — corrupting `state` exactly like the bug #123 set out to fix.

## Fix

Locate the URL anywhere on the line, and reduce every fragment to its run of URL characters before concatenating. This drops indentation, box-drawing borders, and any pane padding, at both the start and the continuation lines. Applied to both copies of the extraction (the watcher and the SSH-based `claude-login-url` fallback), which have been identical since #124.

## Testing

Tested against the **real shipped `extract_url`** (sourced from the script, with `tmux` stubbed), under **both** `mawk` and **busybox awk** — the latter is what actually runs in the Alpine container — 9/9 cases pass in each:

| Case | Result |
|---|---|
| flush-left 3-line wrap (the #123 regression case) | pass |
| indented 4 spaces | pass |
| bordered panel with box-drawing chars | pass |
| prose before the URL on the same line | pass |
| most recent of two URLs wins | pass |
| single-line URL | pass |
| no URL present → empty | pass |
| trailing pane padding stripped | pass |
| whitespace-only line terminates collection | pass |

Also ran `claude-login-url.sh` end-to-end against a fake bordered pane: correct URL written, file mode 600. `shellcheck -s bash -S warning` and `bash -n` clean.

## Note

This is **not** the cause of the still-open 400 reported in #122 — that reporter confirmed they are on 2.5.2, the notification *did* appear, and the link still fails. That's being tracked separately. This PR is robustness for a failure mode we have not yet had confirmed in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG)_