### PR TITLE
fix(claude-terminal): clear a stale login notification on startup

### DIFF
--- a/claude-terminal/scripts/login-url-watcher.sh
+++ b/claude-terminal/scripts/login-url-watcher.sh
@@ -70,6 +70,14 @@ dismiss() {
         http://supervisor/core/api/services/persistent_notification/dismiss >/dev/null 2>&1
 }
 
+# Clear any notification left over from a previous container before the loop
+# starts publishing current ones. The login URL's state/PKCE challenge belongs
+# to the specific `claude` process that produced it, and Home Assistant's
+# persistent notifications outlive the add-on — so a notification surviving a
+# restart points at a process that no longer exists, and authorizing against
+# it fails every time with no hint that the link is simply dead.
+dismiss
+
 last_url=""
 notified=0
 


### PR DESCRIPTION
## Problem

The login URL's `state` and PKCE challenge belong to the specific `claude` process that produced them. Home Assistant's persistent notifications, however, outlive the add-on container.

So after an add-on restart that follows an incomplete login, the "Claude Code login" notification is still sitting in the user's panel — pointing at a process that no longer exists. Authorizing against it returns a 400 every time, and nothing distinguishes "this link is dead" from "the add-on is broken." The watcher only dismissed on *successful* login, so a dead link could persist indefinitely.

This is a candidate explanation for the 400 still being reported in #122 on 2.5.2 by a user who confirmed the notification appeared and both of its links failed identically — both links in one notification are the same URL, which is what a single stale URL looks like. **Not yet confirmed by that reporter**; the fix stands on its own regardless.

## Fix

Dismiss any leftover notification once at watcher startup, before the loop begins publishing current ones. Three lines plus rationale.

## Testing

Ran the real script with `tmux`/`curl` stubbed, asserting the ordered sequence of `persistent_notification` endpoints actually hit:

| Scenario | Expected | Result |
|---|---|---|
| Not logged in, URL in pane | `dismiss` **then** `create` | pass — stale link cleared before the fresh one is published |
| Already logged in at startup | `dismiss` only, never `create` | pass — no spurious login prompt |

`shellcheck -s bash -S warning` and `bash -n` clean.

## Scope note

This closes the cross-restart case, which is the one users actually hit. It does **not** try to detect a URL going stale *within* a live container (the originating `claude` process dying while its URL sits in scrollback) — that needs a signal the watcher doesn't currently have, and I'd rather not guess at one before there's evidence it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG)_