### PR TITLE
feat(claude-terminal): working_directory and claude_code_oauth_token options

### DIFF
--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -22,6 +22,8 @@ Your credentials are stored under `/data` and persist across restarts and add-on
 |--------|---------|-------------|
 | `auto_launch_claude` | `true` | Start Claude immediately when the terminal opens. Set to `false` to get a shell instead (run `claude` yourself). |
 | `claude_auto_update` | `true` | Keep Claude Code current: installs the official native build into `/data` and updates it in the background on each startup. |
+| `working_directory` | `""` | Directory the terminal session starts in (default `/config`), e.g. `/config/ai_repo`. Claude asks its one-time folder-trust question on first use of a new directory. A non-existent path falls back to `/config` with a warning. |
+| `claude_code_oauth_token` | `""` | Long-lived token from `claude setup-token`, for non-interactive authentication — useful when the OAuth browser flow is impractical. Note: token auth cannot establish [Remote Control](https://code.claude.com/docs/en/remote-control) sessions; use the normal login for that. Stored in the add-on configuration (masked in the UI, but included in HA backups like all add-on options). |
 | `dangerously_skip_permissions` | `false` | Launch Claude with `--dangerously-skip-permissions` (no confirmation prompts). **Read the security note below.** |
 | `claude_extra_args` | `""` | Extra flags appended to every Claude launch, e.g. `--model claude-sonnet-5`. Parsed like a shell command line, so quoting works: `--append-system-prompt 'be terse'` arrives as one argument. |
 | `ha_smart_context` | `true` | Generate a CLAUDE.md with your HA system info so Claude knows your setup. |

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -35,6 +35,8 @@ ports_description:
 options:
   auto_launch_claude: true
   claude_auto_update: true
+  working_directory: ""
+  claude_code_oauth_token: ""
   dangerously_skip_permissions: false
   claude_extra_args: ""
   ha_smart_context: true
@@ -45,6 +47,8 @@ options:
 schema:
   auto_launch_claude: bool?
   claude_auto_update: bool?
+  working_directory: str?
+  claude_code_oauth_token: password?
   dangerously_skip_permissions: bool?
   claude_extra_args: str?
   ha_smart_context: bool?

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -372,6 +372,38 @@ build_claude_flags() {
     echo "$flags"
 }
 
+# Directory the session starts in. Defaults to /config; a configured value
+# must exist, or we warn and fall back — a typo'd path must never take the
+# terminal down. Claude Code shows its one-time per-directory trust prompt
+# on first use of a new directory (stored in ~/.claude.json), then remembers.
+get_working_directory() {
+    local dir
+    dir=$(bashio::config 'working_directory' '')
+    if [ -z "$dir" ] || [ "$dir" = "null" ]; then
+        echo "/config"
+        return 0
+    fi
+    if [ -d "$dir" ]; then
+        echo "$dir"
+    else
+        bashio::log.warning "working_directory '$dir' does not exist; starting in /config instead"
+        echo "/config"
+    fi
+}
+
+# Non-interactive auth (#116): a token from `claude setup-token` set here
+# reaches the auto-launched claude via the environment — the tmux session
+# command runs through a non-interactive shell, so ~/.bashrc exports never
+# reach it. The value itself is never logged.
+export_oauth_token() {
+    local token
+    token=$(bashio::config 'claude_code_oauth_token' '')
+    if [ -n "$token" ] && [ "$token" != "null" ]; then
+        export CLAUDE_CODE_OAUTH_TOKEN="$token"
+        bashio::log.info "CLAUDE_CODE_OAUTH_TOKEN set from add-on configuration"
+    fi
+}
+
 # The command tmux runs inside the session. tmux hands this string to a
 # shell, which is the single parse claude_extra_args goes through.
 get_session_command() {
@@ -401,8 +433,9 @@ start_web_terminal() {
         bashio::log.warning "=========================================================="
     fi
 
-    local session_command
+    local session_command workdir
     session_command=$(get_session_command "$flags")
+    workdir=$(get_working_directory)
 
     bashio::log.info "Starting web terminal on port ${port} (auto_launch_claude=$(bashio::config 'auto_launch_claude' 'true'))"
 
@@ -425,7 +458,7 @@ start_web_terminal() {
         --client-option reconnectInterval=5 \
         --client-option "theme=${ttyd_theme}" \
         --client-option fontSize=14 \
-        tmux new-session -A -s claude "$session_command"
+        tmux new-session -A -s claude -c "$workdir" "$session_command"
 }
 
 # Setup ha-mcp (Home Assistant MCP Server) for Claude Code integration
@@ -445,6 +478,7 @@ main() {
 
     init_environment
     check_cpu_features
+    export_oauth_token
     setup_commands
     update_claude
     install_persistent_packages

--- a/claude-terminal/scripts/tmux.conf
+++ b/claude-terminal/scripts/tmux.conf
@@ -31,7 +31,7 @@ set -g pane-active-border-style "fg=colour167"
 set -g message-style "fg=colour167,bg=#1a1b26"
 
 # Ensure environment variables propagate to status script
-set -g update-environment "SUPERVISOR_TOKEN ANTHROPIC_CONFIG_DIR XDG_CONFIG_HOME HOME"
+set -g update-environment "SUPERVISOR_TOKEN CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_CONFIG_DIR XDG_CONFIG_HOME HOME"
 
 # Mouse support — the wheel scrolls tmux history (copy-mode), drag selects
 # text and copies it to the browser clipboard via OSC 52 (see below).


### PR DESCRIPTION
Two small opt-in options, both resolving long-standing asks:

## `working_directory` (from #91)

Starts the tmux session in a configurable directory (default `/config`) via `tmux new-session -c`, so users whose work lives in e.g. `/config/ai_repo` land there directly. A non-existent path warns and falls back to `/config` — a typo'd option must never take the terminal down. Claude Code's folder-trust prompt fires **once** per new directory (stored per-project in `~/.claude.json`), and a session started in a subdirectory can still reach the rest of `/config` through normal permission rules (or unrestricted with `dangerously_skip_permissions`).

This is the `working_directory` third of #91, adapted for the 2.5.x architecture and credited to @heman22union. The other two parts (interactive per-session prompt; relocating Claude data into `/config`) are declined per maintainer decision — rationale on the PR.

## `claude_code_oauth_token` (fixes #116)

A `claude setup-token` token exported into the environment the auto-launched `claude` inherits. Root cause of #116: the tmux session command runs through a **non-interactive** shell, so `~/.bashrc` exports never reach the auto-launched process — an env file sourced in the terminal works for manual launches only. Schema type `password` masks the value in the UI; it is never logged; `tmux update-environment` carries it across re-attaches. Documented caveat: token auth cannot establish Remote Control sessions (per Anthropic's authentication docs) — use the normal login for that.

## Validation

- `shellcheck -s bash -S warning` clean; config.yaml parses with both schema entries (`str?`, `password?`).
- `get_working_directory`: unset/`null` → `/config`; valid dir → that dir; non-existent → warning **on stderr** + `/config` (verified the command substitution captures a clean path, since bashio logs to stderr).
- `export_oauth_token`: set → exported without the value appearing in any log line; unset → env stays unset.
- Not run: a live container login with a real token — worth a smoke test on real hardware before the next release.

Fixes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb6otV5MWFa1TwwAxcmEZG)_